### PR TITLE
Add GitHub Action to lint and test helm chart install

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,42 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.1
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ct.yml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
 Once Helm is set up properly, add the repo as follows:
 
-```bash 
+```bash
 helm repo add cdf https://cdfoundation.github.io/tekton-helm-chart/
 ```
 
@@ -27,13 +27,8 @@ The chart installs resources into the `tekton-pipelines` namespace
 
 See chart [readme](charts/tekton-pipeline/README.md) for install and config options.
 
-## Repository 
+## Repository
 
 You can [browse the chart repository](https://cdfoundation.github.io/tekton-helm-chart/)
 
 Or view the YAML at: [index.yaml](https://cdfoundation.github.io/tekton-helm-chart/index.yaml)
-
-
-
-
-

--- a/ct.yml
+++ b/ct.yml
@@ -1,0 +1,8 @@
+# See https://github.com/helm/chart-testing#configuration
+chart-dirs:
+  - charts
+remote: origin
+target-branch: master
+validate-maintainers: false
+helm-extra-args: --timeout 800s
+upgrade: false


### PR DESCRIPTION
This PR adds a recommend way to lint and test the helm chart installation in a K8s cluster.
This adds more confidence that the chart can be installed and it is working.

This will be the First PR and the follow-ups will be to fix some issues that were observed in https://github.com/cdfoundation/tekton-helm-chart/issues/7 and some other changes that are required.

Please let me know your thoughts.
/assign @tracymiranda @jstrachan 

/cc more for FYI @markyjackson-taulia @jsalinas29