### PR TITLE
feat: allow customization of the resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ fetch:
 	curl https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml > ${CHART_DIR}/templates/resource.yaml
 	jx gitops split -d ${CHART_DIR}/templates
 	jx gitops rename -d ${CHART_DIR}/templates
+	# kustomize the resources to include some helm template blocs
+	kustomize build ${CHART_DIR} | sed '/helmTemplateRemoveMe/d' > ${CHART_DIR}/templates/resource.yaml
+	jx gitops split -d ${CHART_DIR}/templates
+	jx gitops rename -d ${CHART_DIR}/templates
 	cp src/templates/* ${CHART_DIR}/templates
 	git add charts
 

--- a/charts/tekton-pipeline/.helmignore
+++ b/charts/tekton-pipeline/.helmignore
@@ -1,0 +1,2 @@
+kustomization.yaml
+patches

--- a/charts/tekton-pipeline/Chart.yaml
+++ b/charts/tekton-pipeline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Tekton Pipelines
 name: tekton-pipeline
-version: 0.21.0
+version: 0.21.1
 appVersion: 0.21.0
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/cdfoundation/tekton-helm-chart

--- a/charts/tekton-pipeline/kustomization.yaml
+++ b/charts/tekton-pipeline/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- templates/tekton-pipelines-controller-deploy.yaml
+- templates/tekton-pipelines-webhook-deploy.yaml
+
+patchesStrategicMerge:
+- patches/tekton-pipelines-controller-deploy.yaml
+- patches/tekton-pipelines-webhook-deploy.yaml

--- a/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+  labels:
+    helmTemplateRemoveMe: |
+      {{- with .Values.controller.deployment.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end}}
+spec:
+  template:
+    metadata:
+      labels:
+        helmTemplateRemoveMe: |
+          {{- with .Values.controller.pod.labels }}
+            {{- toYaml . | nindent 8 }}
+          {{- end}}

--- a/charts/tekton-pipeline/patches/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-webhook-deploy.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
+  labels:
+    helmTemplateRemoveMe: |
+      {{- with .Values.webhook.deployment.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end}}
+spec:
+  template:
+    metadata:
+      labels:
+        helmTemplateRemoveMe: |
+          {{- with .Values.webhook.pod.labels }}
+            {{- toYaml . | nindent 8 }}
+          {{- end}}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -1,136 +1,129 @@
-# Copyright 2019 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tekton-pipelines-controller
-  namespace: tekton-pipelines
   labels:
-    app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.21.0"
+    app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: tekton-pipelines
-    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.21.0"
-    # labels below are related to istio and should not be used for resource lookup
-    version: "v0.21.0"
+    app.kubernetes.io/version: v0.21.0
+      {{- with .Values.controller.deployment.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end}}
+    pipeline.tekton.dev/release: v0.21.0
+    version: v0.21.0
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: controller
       app.kubernetes.io/component: controller
       app.kubernetes.io/instance: default
+      app.kubernetes.io/name: controller
       app.kubernetes.io/part-of: tekton-pipelines
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app.kubernetes.io/name: controller
+        app: tekton-pipelines-controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v0.21.0"
+        app.kubernetes.io/name: controller
         app.kubernetes.io/part-of: tekton-pipelines
-        # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v0.21.0"
-        # labels below are related to istio and should not be used for resource lookup
-        app: tekton-pipelines-controller
-        version: "v0.21.0"
+        app.kubernetes.io/version: v0.21.0
+          {{- with .Values.controller.pod.labels }}
+            {{- toYaml . | nindent 8 }}
+          {{- end}}
+        pipeline.tekton.dev/release: v0.21.0
+        version: v0.21.0
     spec:
-      serviceAccountName: tekton-pipelines-controller
       containers:
-        - name: tekton-pipelines-controller
-          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.21.0@sha256:972ee9c3f43c88495b074bfc0a8350eb34131355ab9ddc5da63c59f64d74e83d
-          args: [
-            # Version, to be replace at release time
-            "-version", "v0.21.0",
-            # These images are built on-demand by `ko resolve` and are replaced
-            # by image references by digest.
-            "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.21.0@sha256:1727868bd5a22dd8e45a4efca0a7f0b5b00cd1bbbe97068e60986ae221b828c3", "-git-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0@sha256:db18a9c1607c8cbbcd72f61d0c4d795b9ff528669deacd5f8a1672e4ef198ffd", "-entrypoint-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.21.0@sha256:d5af7d58c2ad222548e7fcaf7d8e8172837df254b49cc636d1f9d0d8c499beb8", "-nop-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.21.0@sha256:8172a046a040a6267888ab9755b48631bbcf92ea58534ae506bb80125ee94cc2", "-imagedigest-exporter-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.21.0@sha256:265641edf8fbb19f844f7d2006d1b81927f43fd1b19f037709355938a1e3c78e", "-pr-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.21.0@sha256:6e2c398d27d5d9f6de3a41ed2d70d9c940e22a648a349c5cb5bbdbb76484c9fe", "-build-gcs-fetcher-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher:v0.21.0@sha256:41c251a2cc7e7c6e6c0f8d3bc3f0c3cc6a980325e754d4d95570c775a2a80b35",
-            # This is gcr.io/google.com/cloudsdktool/cloud-sdk:302.0.0-slim
-            "-gsutil-image", "gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f",
-            # The shell image must be root in order to create directories and copy files to PVCs.
-            # gcr.io/distroless/base:debug as of November 15, 2020
-            # image shall not contains tag, so it will be supported on a runtime like cri-o
-            "-shell-image", "gcr.io/distroless/base@sha256:92720b2305d7315b5426aec19f8651e9e04222991f877cae71f40b3141d2f07e"]
-          volumeMounts:
-            - name: config-logging
-              mountPath: /etc/config-logging
-            - name: config-registry-cert
-              mountPath: /etc/config-registry-cert
-          env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            # If you are changing these names, you will also need to update
-            # the controller's Role in 200-role.yaml to include the new
-            # values in the "configmaps" "get" rule.
-            - name: CONFIG_DEFAULTS_NAME
-              value: config-defaults
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: CONFIG_ARTIFACT_BUCKET_NAME
-              value: config-artifact-bucket
-            - name: CONFIG_ARTIFACT_PVC_NAME
-              value: config-artifact-pvc
-            - name: CONFIG_FEATURE_FLAGS_NAME
-              value: feature-flags
-            - name: CONFIG_LEADERELECTION_NAME
-              value: config-leader-election
-            - name: SSL_CERT_FILE
-              value: /etc/config-registry-cert/cert
-            - name: SSL_CERT_DIR
-              value: /etc/ssl/certs
-            - name: METRICS_DOMAIN
-              value: tekton.dev/pipeline
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - all
-            # User 65532 is the distroless nonroot user ID
-            runAsUser: 65532
-            runAsGroup: 65532
-          ports:
-            - name: probes
-              containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: probes
-              scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: probes
-              scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
+      - args:
+        - -version
+        - v0.21.0
+        - -kubeconfig-writer-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.21.0@sha256:1727868bd5a22dd8e45a4efca0a7f0b5b00cd1bbbe97068e60986ae221b828c3
+        - -git-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0@sha256:db18a9c1607c8cbbcd72f61d0c4d795b9ff528669deacd5f8a1672e4ef198ffd
+        - -entrypoint-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.21.0@sha256:d5af7d58c2ad222548e7fcaf7d8e8172837df254b49cc636d1f9d0d8c499beb8
+        - -nop-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.21.0@sha256:8172a046a040a6267888ab9755b48631bbcf92ea58534ae506bb80125ee94cc2
+        - -imagedigest-exporter-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.21.0@sha256:265641edf8fbb19f844f7d2006d1b81927f43fd1b19f037709355938a1e3c78e
+        - -pr-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.21.0@sha256:6e2c398d27d5d9f6de3a41ed2d70d9c940e22a648a349c5cb5bbdbb76484c9fe
+        - -build-gcs-fetcher-image
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher:v0.21.0@sha256:41c251a2cc7e7c6e6c0f8d3bc3f0c3cc6a980325e754d4d95570c775a2a80b35
+        - -gsutil-image
+        - gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f
+        - -shell-image
+        - gcr.io/distroless/base@sha256:92720b2305d7315b5426aec19f8651e9e04222991f877cae71f40b3141d2f07e
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_DEFAULTS_NAME
+          value: config-defaults
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: CONFIG_ARTIFACT_BUCKET_NAME
+          value: config-artifact-bucket
+        - name: CONFIG_ARTIFACT_PVC_NAME
+          value: config-artifact-pvc
+        - name: CONFIG_FEATURE_FLAGS_NAME
+          value: feature-flags
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election
+        - name: SSL_CERT_FILE
+          value: /etc/config-registry-cert/cert
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        - name: METRICS_DOMAIN
+          value: tekton.dev/pipeline
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.21.0@sha256:972ee9c3f43c88495b074bfc0a8350eb34131355ab9ddc5da63c59f64d74e83d
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        name: tekton-pipelines-controller
+        ports:
+        - containerPort: 8080
+          name: probes
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          runAsGroup: 65532
+          runAsUser: 65532
+        volumeMounts:
+        - mountPath: /etc/config-logging
+          name: config-logging
+        - mountPath: /etc/config-registry-cert
+          name: config-registry-cert
+      serviceAccountName: tekton-pipelines-controller
       volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging
-        - name: config-registry-cert
-          configMap:
-            name: config-registry-cert
+      - configMap:
+          name: config-logging
+        name: config-logging
+      - configMap:
+          name: config-registry-cert
+        name: config-registry-cert

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -1,135 +1,113 @@
-# Copyright 2020 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  # Note: the Deployment name must be the same as the Service name specified in
-  # config/400-webhook-service.yaml. If you change this name, you must also
-  # change the value of WEBHOOK_SERVICE_NAME below.
-  name: tekton-pipelines-webhook
-  namespace: tekton-pipelines
   labels:
-    app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.21.0"
+    app.kubernetes.io/name: webhook
     app.kubernetes.io/part-of: tekton-pipelines
-    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.21.0"
-    # labels below are related to istio and should not be used for resource lookup
-    version: "v0.21.0"
+    app.kubernetes.io/version: v0.21.0
+      {{- with .Values.webhook.deployment.labels }}
+        {{- toYaml . | nindent 4 }}
+      {{- end}}
+    pipeline.tekton.dev/release: v0.21.0
+    version: v0.21.0
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: webhook
       app.kubernetes.io/component: webhook
       app.kubernetes.io/instance: default
+      app.kubernetes.io/name: webhook
       app.kubernetes.io/part-of: tekton-pipelines
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app.kubernetes.io/name: webhook
+        app: tekton-pipelines-webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v0.21.0"
+        app.kubernetes.io/name: webhook
         app.kubernetes.io/part-of: tekton-pipelines
-        # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v0.21.0"
-        # labels below are related to istio and should not be used for resource lookup
-        app: tekton-pipelines-webhook
-        version: "v0.21.0"
+        app.kubernetes.io/version: v0.21.0
+          {{- with .Values.webhook.pod.labels }}
+            {{- toYaml . | nindent 8 }}
+          {{- end}}
+        pipeline.tekton.dev/release: v0.21.0
+        version: v0.21.0
     spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: webhook
-                    app.kubernetes.io/component: webhook
-                    app.kubernetes.io/instance: default
-                    app.kubernetes.io/part-of: tekton-pipelines
-                topologyKey: kubernetes.io/hostname
-              weight: 100
-      serviceAccountName: tekton-pipelines-webhook
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: webhook
+                  app.kubernetes.io/instance: default
+                  app.kubernetes.io/name: webhook
+                  app.kubernetes.io/part-of: tekton-pipelines
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
-        - name: webhook
-          # This is the Go import path for the binary that is containerized
-          # and substituted here.
-          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.21.0@sha256:1c9c9acf8451fd40ce46dc4069d1b589a7fe1b9e5798652beb4f514e4a17e8cb
-          # Resource request required for autoscaler to take any action for a metric
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 500m
-              memory: 500Mi
-          env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            # If you are changing these names, you will also need to update
-            # the webhook's Role in 200-role.yaml to include the new
-            # values in the "configmaps" "get" rule.
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: CONFIG_LEADERELECTION_NAME
-              value: config-leader-election
-            - name: WEBHOOK_SERVICE_NAME
-              value: tekton-pipelines-webhook
-            - name: WEBHOOK_SECRET_NAME
-              value: webhook-certs
-            - name: METRICS_DOMAIN
-              value: tekton.dev/pipeline
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - all
-            # User 65532 is the distroless nonroot user ID
-            runAsUser: 65532
-            runAsGroup: 65532
-          ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
-            - name: https-webhook
-              containerPort: 8443
-            - name: probes
-              containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: probes
-              scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: probes
-              scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election
+        - name: WEBHOOK_SERVICE_NAME
+          value: tekton-pipelines-webhook
+        - name: WEBHOOK_SECRET_NAME
+          value: webhook-certs
+        - name: METRICS_DOMAIN
+          value: tekton.dev/pipeline
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.21.0@sha256:1c9c9acf8451fd40ce46dc4069d1b589a7fe1b9e5798652beb4f514e4a17e8cb
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        name: webhook
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        - containerPort: 8443
+          name: https-webhook
+        - containerPort: 8080
+          name: probes
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          runAsGroup: 65532
+          runAsUser: 65532
+      serviceAccountName: tekton-pipelines-webhook

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -11,3 +11,15 @@ auth:
 serviceaccount:
   enabled: true
   annotations: {}
+
+controller:
+  deployment:
+    labels: {}
+  pod:
+    labels: {}
+
+webhook:
+  deployment:
+    labels: {}
+  pod:
+    labels: {}


### PR DESCRIPTION
I needed to add extra labels on the controller pod (to enable prometheus scraping)
so I came up with a solution to customize the resources, based on kustomize

so we run kustomize to add Helm template blocs - as yaml string values, because otherwise it won't be a valid YAML file and kustomize will fail
and then we use sed to remove the yaml key, and only keep the Helm template bloc

so at the end, we can easily insert helm template blocs in the YAML resources, and add default values