### PR TITLE
Added helm parametrization for config-defaults configmap

### DIFF
--- a/charts/tekton-pipeline/kustomization.yaml
+++ b/charts/tekton-pipeline/kustomization.yaml
@@ -4,7 +4,9 @@ kind: Kustomization
 resources:
 - templates/tekton-pipelines-controller-deploy.yaml
 - templates/tekton-pipelines-webhook-deploy.yaml
+- templates/config-defaults-cm.yaml
 
 patchesStrategicMerge:
 - patches/tekton-pipelines-controller-deploy.yaml
 - patches/tekton-pipelines-webhook-deploy.yaml
+- patches/config-defaults-cm.yaml

--- a/charts/tekton-pipeline/patches/config-defaults-cm.yaml
+++ b/charts/tekton-pipeline/patches/config-defaults-cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+helmTemplateRemoveMe: |
+    {{- if .Values.configDefaults -}}
+      {{- toYaml .Values.configDefaults | nindent 2 }}
+    {{- end -}}

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -24,3 +24,5 @@ webhook:
     labels: {}
   pod:
     labels: {}
+
+configDefaults: {}


### PR DESCRIPTION
### Reason for the change

_As a user, I would like at "helm install" to be able to tweak some default values in the config-defaults configmap_. This PR adds this functionality by introducing the **configDefaults** dict. All the values under this variable will be added to the **data:** section of the ConfigMap

 ### Testing

Tested by issuing a **make fetch** and deploying the resulting helm chart locally.