### PR TITLE
Revert "Revert "fix: upgrade to 0.29.0""

### DIFF
--- a/charts/tekton-pipeline/Chart.yaml
+++ b/charts/tekton-pipeline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Tekton Pipelines
 name: tekton-pipeline
-version: 0.27.2
-appVersion: 0.27.2
+version: 0.29.0
+appVersion: 0.29.0
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/cdfoundation/tekton-helm-chart

--- a/charts/tekton-pipeline/templates/clustertasks.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/templates/clustertasks.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
-    version: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/templates/conditions.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/templates/conditions.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
-    version: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   versions:

--- a/charts/tekton-pipeline/templates/config-observability-cm.yaml
+++ b/charts/tekton-pipeline/templates/config-observability-cm.yaml
@@ -54,3 +54,7 @@ data:
     # charge.  If metrics.backend-destination is not Stackdriver, this is
     # ignored.
     metrics.allow-stackdriver-custom-metrics: "false"
+    metrics.taskrun.level: "taskrun"
+    metrics.taskrun.duration-type: "histogram"
+    metrics.pipelinerun.level: "pipelinerun"
+    metrics.pipelinerun.duration-type: "histogram"

--- a/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/pipelineresources.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/templates/pipelineresources.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
-    version: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   versions:

--- a/charts/tekton-pipeline/templates/pipelineruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/templates/pipelineruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
-    version: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
+++ b/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
@@ -26,4 +26,4 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace we still can have access to
   # this ConfigMap.
-  version: "v0.27.0"
+  version: "v0.29.0"

--- a/charts/tekton-pipeline/templates/pipelines.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/templates/pipelines.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
-    version: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/templates/runs.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/templates/runs.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
-    version: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/templates/taskruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/templates/taskruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
-    version: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/templates/tasks.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/templates/tasks.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
-    version: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
+    version: "v0.29.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v0.27.0
+    app.kubernetes.io/version: v0.29.0
       {{- with .Values.controller.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v0.27.0
-    version: v0.27.0
+    pipeline.tekton.dev/release: v0.29.0
+    version: v0.29.0
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
 spec:
@@ -35,12 +35,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: controller
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v0.27.0
+        app.kubernetes.io/version: v0.29.0
           {{- with .Values.controller.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v0.27.0
-        version: v0.27.0
+        pipeline.tekton.dev/release: v0.29.0
+        version: v0.29.0
     spec:
       affinity:
         nodeAffinity:
@@ -54,21 +54,23 @@ spec:
       containers:
       - args:
         - -kubeconfig-writer-image
-        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.27.0@sha256:81074a7039daa1f2d579e74fdc0b41eeac0c1136bf6a487f67ff14240aaac378
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.29.0@sha256:6d058f2203b9ab66f538cb586c7dc3b7cc31ae958a4135dd99e51799f24b06c9
         - -git-image
-        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.27.0@sha256:8bfb6edbd8ce4608af957a3a38444512c14713bc9fc0d60308f228c61be4c83f
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.29.0@sha256:c0b0ed1cd81090ce8eecf60b936e9345089d9dfdb6ebdd2fd7b4a0341ef4f2b9
         - -entrypoint-image
-        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.27.0@sha256:b8a0bed8e402138f7b14b44115719f44460255497132b8a8233e710692ef6930
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.29.0@sha256:66958b78766741c25e31954f47bc9fd53eaa28263506b262bf2cc6df04f18561
         - -nop-image
-        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.27.0@sha256:96c203f18b3eba750fcbf9c018ac1c97a68860053035524f3629ef7093a64d9c
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.29.0@sha256:6a037d5ba27d9c6be32a9038bfe676fb67d2e4145b4f53e9c61fb3e69f06e816
         - -imagedigest-exporter-image
-        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.27.0@sha256:32fa5aa9d17c0e999053e515264b70037168760fc835cbb513c6e92b3afc77bb
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.29.0@sha256:e38dd0d32253fce5aaf1e501c0bc71facc3720564b7e97055921cc5390d612e0
         - -pr-image
-        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.27.0@sha256:fe7734cced1b9a2ce37dd78df5fc5998d29ac8bef8e8bd984c6b6a8bbb58e4f4
+        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.29.0@sha256:d28202fb8b33a1d4c05f261ef8dcbcdcf3b469887d4dad256ce91f73c917420e
         - -gsutil-image
         - gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f
         - -shell-image
         - gcr.io/distroless/base@sha256:aa4fd987555ea10e1a4ec8765da8158b5ffdfef1e72da512c7ede509bc9966c4
+        - -shell-image-win
+        - mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -104,7 +106,7 @@ spec:
         - secretRef:
             name: '{{ .Values.controller.envFromSecret }}'
             optional: true
-        image: ghcr.io/jenkins-x/controller-10a3e32792f33651396d02b6855a6e36:latest
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.29.0@sha256:72f79471f06d096cc53e51385017c9f0f7edbc87379bf415f99d4bd11cf7bc2b
         livenessProbe:
           httpGet:
             path: /health

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.27.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-controller
-    version: "v0.27.0"
+    version: "v0.29.0"
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
 spec:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-cluster-access-clusterrole.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-cluster-access-clusterrole.yaml
@@ -25,7 +25,7 @@ rules:
     resourceNames: ["webhook.pipeline.tekton.dev"]
     # When there are changes to the configs or secrets, knative updates the mutatingwebhook config
     # with the updated certificates or the refreshed set of rules.
-    verbs: ["get", "update"]
+    verbs: ["get", "update", "delete"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
     # validation.webhook.pipeline.tekton.dev performs schema validation when you, for example, create TaskRuns.
@@ -33,7 +33,7 @@ rules:
     resourceNames: ["validation.webhook.pipeline.tekton.dev", "config.webhook.pipeline.tekton.dev"]
     # When there are changes to the configs or secrets, knative updates the validatingwebhook config
     # with the updated certificates or the refreshed set of rules.
-    verbs: ["get", "update"]
+    verbs: ["get", "update", "delete"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]
     resourceNames: ["tekton-pipelines"]
@@ -43,4 +43,10 @@ rules:
     verbs: ["get"]
     # The webhook configured the namespace as the OwnerRef on various cluster-scoped resources,
     # which requires we can Get the system namespace.
+    resourceNames: ["tekton-pipelines"]
+  - apiGroups: [""]
+    resources: ["namespaces/finalizers"]
+    verbs: ["update"]
+    # The webhook configured the namespace as the OwnerRef on various cluster-scoped resources,
+    # which requires we can update the system namespace finalizers.
     resourceNames: ["tekton-pipelines"]

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v0.27.0
+    app.kubernetes.io/version: v0.29.0
       {{- with .Values.webhook.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v0.27.0
-    version: v0.27.0
+    pipeline.tekton.dev/release: v0.29.0
+    version: v0.29.0
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
 spec:
@@ -30,12 +30,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: webhook
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v0.27.0
+        app.kubernetes.io/version: v0.29.0
           {{- with .Values.webhook.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v0.27.0
-        version: v0.27.0
+        pipeline.tekton.dev/release: v0.29.0
+        version: v0.29.0
     spec:
       affinity:
         nodeAffinity:
@@ -69,6 +69,8 @@ spec:
           value: config-observability
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
+        - name: CONFIG_FEATURE_FLAGS_NAME
+          value: feature-flags
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-pipelines-webhook
         - name: WEBHOOK_SECRET_NAME
@@ -79,7 +81,7 @@ spec:
         - secretRef:
             name: '{{ .Values.webhook.envFromSecret }}'
             optional: true
-        image: ghcr.io/jenkins-x/webhook-d4749e605405422fd87700164e31b2d1:latest
+        image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.29.0@sha256:46d5b90a7f4e9996351ad893a26bcbd27216676ad4d5316088ce351fb2c2c3dd
         livenessProbe:
           httpGet:
             path: /health

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
@@ -21,12 +21,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.27.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v0.27.0"
+    version: "v0.29.0"
 spec:
   minReplicas: 1
   maxReplicas: 5

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-role.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-role.yaml
@@ -15,7 +15,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
-    resourceNames: ["config-logging", "config-observability", "config-leader-election"]
+    resourceNames: ["config-logging", "config-observability", "config-leader-election", "feature-flags"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["list", "watch"]

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.27.0"
+    app.kubernetes.io/version: "v0.29.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-webhook
-    version: "v0.27.0"
+    version: "v0.29.0"
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
 spec:

--- a/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
+++ b/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
@@ -21,5 +21,5 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
 # The data is populated at install time.

--- a/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.27.0"
+    pipeline.tekton.dev/release: "v0.29.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:


### PR DESCRIPTION
Reverts cdfoundation/tekton-helm-chart#23. the initial revert was made in order to push chart version 0.27.2 back to the correct remote version.