### PR TITLE
fix: Prevent duplicates in config maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ CDF official helm chart for [Tekton Pipelines](https://github.com/tektoncd/pipel
 
 ## Usage
 
-Ensure that you have [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) installed.
+## Prerequisites
+
+The following tools need to be installed locally:
+
+- [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
+- [yq](https://github.com/mikefarah/yq/#install)
 
 ### Jenkins X
 
@@ -27,7 +32,7 @@ Also, remember to change the `version` in `charts/tekton-pipeline/Chart.yaml`.
 The `app_version` will be set to the `CHART_VERSION` automatically by the makefile if a `CHART_VERSION` is specified.
 For latest set `app_version` to the latest tekton version from the [tekton release page](https://github.com/tektoncd/pipeline/releases) and not `latest`.
 
-### Other usecases
+### Other use cases
 
 [Helm](https://helm.sh) must be installed to use the charts.
 Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
@@ -48,10 +53,8 @@ The chart installs resources into the `tekton-pipelines` namespace
 
 ## Configuration
 
-See chart [readme](charts/tekton-pipeline/README.md) for install and config options.
+See chart [readme](charts/tekton-pipeline/README.md) and [values.yaml](charts/tekton-pipeline/values.yaml) for install and config options.
 
 ## Repository
 
-You can [browse the chart repository](https://cdfoundation.github.io/tekton-helm-chart/)
-
-Or view the YAML at: [index.yaml](https://cdfoundation.github.io/tekton-helm-chart/index.yaml)
+You can view the YAML at [index.yaml](https://cdfoundation.github.io/tekton-helm-chart/index.yaml).

--- a/charts/tekton-pipeline/Chart.yaml
+++ b/charts/tekton-pipeline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for Tekton Pipelines
 name: tekton-pipeline
-version: 0.1.0
+version: 0.2.0
 appVersion: 0.32.4
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/cdfoundation/tekton-helm-chart

--- a/charts/tekton-pipeline/patches/config-defaults-cm.yaml
+++ b/charts/tekton-pipeline/patches/config-defaults-cm.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: tekton-pipelines
 data:
   helmTemplateRemoveMe: |
-    {{- if .Values.configDefaults -}}{{- toYaml .Values.configDefaults | nindent 2 }}{{ end }}
+    {{- toYaml .Values.configDefaults | nindent 2 }}

--- a/charts/tekton-pipeline/patches/feature-flags-cm.yaml
+++ b/charts/tekton-pipeline/patches/feature-flags-cm.yaml
@@ -3,5 +3,6 @@ kind: ConfigMap
 metadata:
   name: feature-flags
   namespace: tekton-pipelines
-helmTemplateRemoveMe: |
-  {{- if .Values.featureFlags -}}{{- toYaml .Values.featureFlags | nindent 2 }}{{ end }}
+data:
+  helmTemplateRemoveMe: |
+    {{- toYaml .Values.featureFlags | nindent 2 }}

--- a/charts/tekton-pipeline/templates/config-defaults-cm.yaml
+++ b/charts/tekton-pipeline/templates/config-defaults-cm.yaml
@@ -1,53 +1,6 @@
 apiVersion: v1
 data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # default-timeout-minutes contains the default number of
-    # minutes to use for TaskRun and PipelineRun, if none is specified.
-    default-timeout-minutes: "60"  # 60 minutes
-
-    # default-service-account contains the default service account name
-    # to use for TaskRun and PipelineRun, if none is specified.
-    default-service-account: "default"
-
-    # default-managed-by-label-value contains the default value given to the
-    # "app.kubernetes.io/managed-by" label applied to all Pods created for
-    # TaskRuns. If a user's requested TaskRun specifies another value for this
-    # label, the user's request supercedes.
-    default-managed-by-label-value: "tekton-pipelines"
-
-    # default-pod-template contains the default pod template to use
-    # TaskRun and PipelineRun, if none is specified. If a pod template
-    # is specified, the default pod template is ignored.
-    # default-pod-template:
-
-    # default-cloud-events-sink contains the default CloudEvents sink to be
-    # used for TaskRun and PipelineRun, when no sink is specified.
-    # Note that right now it is still not possible to set a PipelineRun or
-    # TaskRun specific sink, so the default is the only option available.
-    # If no sink is specified, no CloudEvent is generated
-    # default-cloud-events-sink:
-
-    # default-task-run-workspace-binding contains the default workspace
-    # configuration provided for any Workspaces that a Task declares
-    # but that a TaskRun does not explicitly provide.
-    # default-task-run-workspace-binding: |
-    #   emptyDir: {}
-    {{- if .Values.configDefaults -}}{{- toYaml .Values.configDefaults | nindent 2 }}{{ end }}
+    {{- toYaml .Values.configDefaults | nindent 2 }}
 kind: ConfigMap
 metadata:
   labels:

--- a/charts/tekton-pipeline/templates/feature-flags-cm.yaml
+++ b/charts/tekton-pipeline/templates/feature-flags-cm.yaml
@@ -1,16 +1,6 @@
 apiVersion: v1
 data:
-  disable-affinity-assistant: "false"
-  disable-creds-init: "false"
-  disable-home-env-overwrite: "true"
-  disable-working-directory-overwrite: "true"
-  enable-api-fields: stable
-  enable-custom-tasks: "false"
-  enable-tekton-oci-bundles: "false"
-  require-git-ssh-secret-known-hosts: "false"
-  running-in-environment-with-injected-sidecars: "true"
-  scope-when-expressions-to-task: "false"
-  {{- if .Values.featureFlags -}}{{- toYaml .Values.featureFlags | nindent 2 }}{{ end }}
+    {{- toYaml .Values.featureFlags | nindent 2 }}
 kind: ConfigMap
 metadata:
   labels:

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -7,11 +7,9 @@ auth:
     # if specified use the docker config.json style secret like this:
     # https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#configuring-docker-authentication-for-docker
     configJson: ""
-
 serviceaccount:
   enabled: true
   annotations: {}
-
 controller:
   deployment:
     labels: {}
@@ -20,7 +18,6 @@ controller:
     annotations: {}
   # specifies the name of an optional kubernetes secret to mount environment variables from for things like HTTP proxy
   envFromSecret: "tekton-env"
-
 webhook:
   deployment:
     labels: {}
@@ -28,9 +25,118 @@ webhook:
     labels: {}
   # specifies the name of an optional kubernetes secret to mount environment variables from for things like HTTP proxy
   envFromSecret: "tekton-env"
+# configuration to put in the config-defaults ConfigMap
+configDefaults:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
 
-# overrides any configuration in the config-defaults ConfigMap
-configDefaults: {}
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
 
-# overrides any feature flags in the feature-flags ConfigMap
-featureFlags: {}
+    # default-timeout-minutes contains the default number of
+    # minutes to use for TaskRun and PipelineRun, if none is specified.
+    default-timeout-minutes: "60"  # 60 minutes
+
+    # default-service-account contains the default service account name
+    # to use for TaskRun and PipelineRun, if none is specified.
+    default-service-account: "default"
+
+    # default-managed-by-label-value contains the default value given to the
+    # "app.kubernetes.io/managed-by" label applied to all Pods created for
+    # TaskRuns. If a user's requested TaskRun specifies another value for this
+    # label, the user's request supercedes.
+    default-managed-by-label-value: "tekton-pipelines"
+
+    # default-pod-template contains the default pod template to use
+    # TaskRun and PipelineRun, if none is specified. If a pod template
+    # is specified, the default pod template is ignored.
+    # default-pod-template:
+
+    # default-cloud-events-sink contains the default CloudEvents sink to be
+    # used for TaskRun and PipelineRun, when no sink is specified.
+    # Note that right now it is still not possible to set a PipelineRun or
+    # TaskRun specific sink, so the default is the only option available.
+    # If no sink is specified, no CloudEvent is generated
+    # default-cloud-events-sink:
+
+    # default-task-run-workspace-binding contains the default workspace
+    # configuration provided for any Workspaces that a Task declares
+    # but that a TaskRun does not explicitly provide.
+    # default-task-run-workspace-binding: |
+    #   emptyDir: {}
+# feature flags to put in feature-flags ConfigMap
+featureFlags:
+  # Setting this flag to "true" will prevent Tekton to create an
+  # Affinity Assistant for every TaskRun sharing a PVC workspace
+  #
+  # The default behaviour is for Tekton to create Affinity Assistants
+  #
+  # See more in the workspace documentation about Affinity Assistant
+  # https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#affinity-assistant-and-specifying-workspace-order-in-a-pipeline
+  # or https://github.com/tektoncd/pipeline/pull/2630 for more info.
+  disable-affinity-assistant: "false"
+  # Setting this flag to "false" will allow Tekton to override your
+  # Task container's $HOME environment variable.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/2013 for more
+  # info.
+  disable-home-env-overwrite: "true"
+  # Setting this flag to "false" will allow Tekton to override your
+  # Task container's working directory.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/1836 for more
+  # info.
+  disable-working-directory-overwrite: "true"
+  # Setting this flag to "true" will prevent Tekton scanning attached
+  # service accounts and injecting any credentials it finds into your
+  # Steps.
+  #
+  # The default behaviour currently is for Tekton to search service
+  # accounts for secrets matching a specified format and automatically
+  # mount those into your Steps.
+  #
+  # Note: setting this to "true" will prevent PipelineResources from
+  # working.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/2791 for more
+  # info.
+  disable-creds-init: "false"
+  # This option should be set to false when Pipelines is running in a
+  # cluster that does not use injected sidecars such as Istio. Setting
+  # it to false should decrease the time it takes for a TaskRun to start
+  # running. For clusters that use injected sidecars, setting this
+  # option to false can lead to unexpected behavior.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/2080 for more info.
+  running-in-environment-with-injected-sidecars: "true"
+  # Setting this flag to "true" will require that any Git SSH Secret
+  # offered to Tekton must have known_hosts included.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/2981 for more
+  # info.
+  require-git-ssh-secret-known-hosts: "false"
+  # Setting this flag to "true" enables the use of Tekton OCI bundle.
+  # This is an experimental feature and thus should still be considered
+  # an alpha feature.
+  enable-tekton-oci-bundles: "false"
+  # Setting this flag to "true" enables the use of custom tasks from
+  # within pipelines.
+  # This is an experimental feature and thus should still be considered
+  # an alpha feature.
+  enable-custom-tasks: "false"
+  # Setting this flag will determine which gated features are enabled.
+  # Acceptable values are "stable" or "alpha".
+  enable-api-fields: "stable"
+  # Setting this flag to "true" scopes when expressions to guard a Task only
+  # instead of a Task and its dependent Tasks.
+  scope-when-expressions-to-task: "false"


### PR DESCRIPTION
Got problems with kpt when configmap had duplicates. It means an extra requirement on yq, but as far as I can see `make fetch` isn't run automatically anywhere.