### PR TITLE
Amend/resolvers deploy

### DIFF
--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -1,10 +1,14 @@
 name: Increment Version
 
-on: [pull_request, pull_request_target]
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [closed]
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -13,9 +17,8 @@ jobs:
       - name: check source code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
           token: ${{ secrets.ACCESS_TOKEN }}
-        
+          ref: ${{ github.head_ref }}
 
       - name: next release version
         id: nextversion
@@ -32,4 +35,5 @@ jobs:
       - name: Commit Changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
+          branch: main
           commit_message: 'chore: update Chart.yaml'

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ endif
 	yq -i '.controller.deployment.image = load("$(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml").spec.template.spec.containers[].image' $(CHART_DIR)/values.yaml
 	# Remove the image value, so that end users can customize the image
 	yq -i '.spec.template.spec.containers[].image = null' $(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml
+	# Remove duplicated node affinity
+	find $(CHART_DIR)/templates -type f -name "*deploy.yaml" -exec yq -i eval 'del(.spec.template.spec.affinity.nodeAffinity)' "{}" \;
 	# kustomize the resources to include some helm template blocs
 	kustomize build ${CHART_DIR} | sed '/helmTemplateRemoveMe/d' > ${CHART_DIR}/templates/resource.yaml
 	jx gitops split -d ${CHART_DIR}/templates

--- a/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       affinity:
           helmTemplateRemoveMe: |
-            {{- with .Values.controllerDeploymentTolerations.nodeSelectorTerms }}
+            {{- with .Values.controllerDeploymentTolerations.nodeAffinity }}
              {{- toYaml . |  nindent 8 }}
             {{- end }}
       containers:

--- a/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
@@ -23,18 +23,10 @@ spec:
           {{- end}}
     spec:
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            -  helmTemplateRemoveMe: |
-                {{- with .Values.controllerDeploymentTolerations.nodeSelectorTerms }}
-                  {{- toYaml . |  nindent 12 }}
-                {{- end}}
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: NotIn
-                values:
-                  - windows
+          helmTemplateRemoveMe: |
+            {{- with .Values.controllerDeploymentTolerations.nodeSelectorTerms }}
+             {{- toYaml . |  nindent 8 }}
+            {{- end }}
       containers:
       - name: tekton-pipelines-controller
         envFrom:

--- a/charts/tekton-pipeline/patches/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-webhook-deploy.yaml
@@ -16,6 +16,11 @@ spec:
             {{- toYaml . | nindent 8 }}
           {{- end}}
     spec:
+      affinity:
+        helmTemplateRemoveMe: |
+          {{- with .Values.webhookDeploymentTolerations.nodeAffinity }}
+           {{- toYaml . |  nindent 8 }}
+          {{- end }}
       containers:
       - name: webhook
         envFrom:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -42,7 +42,7 @@ spec:
         version: v0.42.0
     spec:
       affinity:
-          {{- with .Values.controllerDeploymentTolerations.nodeSelectorTerms }}
+          {{- with .Values.controllerDeploymentTolerations.nodeAffinity }}
            {{- toYaml . |  nindent 8 }}
           {{- end }}
       containers:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -42,17 +42,9 @@ spec:
         version: v0.42.0
     spec:
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-                {{- with .Values.controllerDeploymentTolerations.nodeSelectorTerms }}
-                  {{- toYaml . |  nindent 12 }}
-                {{- end}}
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: NotIn
-                values:
-                - windows
+          {{- with .Values.controllerDeploymentTolerations.nodeSelectorTerms }}
+           {{- toYaml . |  nindent 8 }}
+          {{- end }}
       containers:
       - args:
         - -kubeconfig-writer-image

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -59,9 +59,9 @@ spec:
                     app.kubernetes.io/part-of: tekton-pipelines
                 topologyKey: kubernetes.io/hostname
               weight: 100
-        {{- with .Values.resolverDeploymentTolerations.nodeAffinity }}
-        nodeAffinity: {{- toYaml . | trim | nindent 10 }}
-        {{- end }}
+      {{- with .Values.resolverDeploymentTolerations.nodeAffinity }}
+      {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       {{- with .Values.resolverDeploymentTolerations.nodeSelector }}
       nodeSelector: {{- toYaml . | trim | nindent 10 }}
       {{- end }}
@@ -73,7 +73,7 @@ spec:
         - name: controller
           image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/resolvers:v0.42.0@sha256:eaa7d21d45f0bc1c411823d6a943e668c820f9cf52f1549d188edb89e992f6e0
           {{- with .Values.remoteResolversPod.resources }}
-          resources: {{- toYaml . | trim | nindent 15 }}
+          resources: {{- toYaml . | trim | nindent 12 }}
           {{- end }}
           ports:
             - name: metrics

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -36,14 +36,9 @@ spec:
         version: v0.42.0
     spec:
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: NotIn
-                values:
-                - windows
+          {{- with .Values.webhookDeploymentTolerations.nodeAffinity }}
+           {{- toYaml . |  nindent 8 }}
+          {{- end }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -97,16 +97,40 @@ remoteResolversPod:
 # Add node affinity tolerations for tekton-remote-resolvers
 resolverDeploymentTolerations:
   nodeAffinity: []
+  #  nodeAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #      nodeSelectorTerms:
+  #        - matchExpressions:
+  #            - key: "key"
+  #              operator: "In"
+  #              values:
+  #                - "node"
   nodeSelector: []
   tolerations: []
 # Add node affinity tolerations for tekton-pipeline-controller
 controllerDeploymentTolerations:
-  nodeSelectorTerms: []
+  nodeAffinity: []
+  #  nodeAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #      nodeSelectorTerms:
+  #        - matchExpressions:
+  #            - key: "key"
+  #              operator: "In"
+  #              values:
+  #                - "node"
   nodeSelector: []
   tolerations: []
 # Add node affinity tolerations for tekton-pipelines-webhook
 webhookDeploymentTolerations:
-  nodeSelectorTerms: []
+  nodeAffinity: []
+  #  nodeAffinity:
+  #    requiredDuringSchedulingIgnoredDuringExecution:
+  #      nodeSelectorTerms:
+  #        - matchExpressions:
+  #            - key: "key"
+  #              operator: "In"
+  #              values:
+  #                - "node"
   nodeSelector: []
   tolerations: []
 gitResolverConfig:

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -96,7 +96,7 @@ remoteResolversPod:
       memory: 100Mi
 # Add node affinity tolerations for tekton-remote-resolvers
 resolverDeploymentTolerations:
-  nodeAffinity: []
+  nodeAffinity: {}
   #  nodeAffinity:
   #    requiredDuringSchedulingIgnoredDuringExecution:
   #      nodeSelectorTerms:
@@ -109,7 +109,7 @@ resolverDeploymentTolerations:
   tolerations: []
 # Add node affinity tolerations for tekton-pipeline-controller
 controllerDeploymentTolerations:
-  nodeAffinity: []
+  nodeAffinity: {}
   #  nodeAffinity:
   #    requiredDuringSchedulingIgnoredDuringExecution:
   #      nodeSelectorTerms:
@@ -122,7 +122,7 @@ controllerDeploymentTolerations:
   tolerations: []
 # Add node affinity tolerations for tekton-pipelines-webhook
 webhookDeploymentTolerations:
-  nodeAffinity: []
+  nodeAffinity: {}
   #  nodeAffinity:
   #    requiredDuringSchedulingIgnoredDuringExecution:
   #      nodeSelectorTerms:

--- a/src/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/src/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -59,9 +59,9 @@ spec:
                     app.kubernetes.io/part-of: tekton-pipelines
                 topologyKey: kubernetes.io/hostname
               weight: 100
-        {{- with .Values.resolverDeploymentTolerations.nodeAffinity }}
-        nodeAffinity: {{- toYaml . | trim | nindent 10 }}
-        {{- end }}
+      {{- with .Values.resolverDeploymentTolerations.nodeAffinity }}
+      {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       {{- with .Values.resolverDeploymentTolerations.nodeSelector }}
       nodeSelector: {{- toYaml . | trim | nindent 10 }}
       {{- end }}
@@ -73,7 +73,7 @@ spec:
         - name: controller
           image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/resolvers:v0.42.0@sha256:eaa7d21d45f0bc1c411823d6a943e668c820f9cf52f1549d188edb89e992f6e0
           {{- with .Values.remoteResolversPod.resources }}
-          resources: {{- toYaml . | trim | nindent 15 }}
+          resources: {{- toYaml . | trim | nindent 12 }}
           {{- end }}
           ports:
             - name: metrics


### PR DESCRIPTION
- amend git-resolvers deployment so overriden values in cluster git repo keep consistency to prevent confusion
- add additional logic to github workflow so it runs the action on the forked repo, pushes to main branch with correct access_token when the PR is merged