### PR TITLE
feat: publish OCI-based charts to GHCR; update app to v1.12.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: check source code
         uses: actions/checkout@v3
@@ -23,8 +26,28 @@ jobs:
             exit 1
           fi
 
-      - uses: J12934/helm-gh-pages-action@master
+      # Publish chart to GitHub Pages
+      - name: Publish chart to GitHub Pages
+        uses: J12934/helm-gh-pages-action@master
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
           charts-folder: "charts"
           deploy-branch: "gh-pages"
+
+      # Publish OCI-based chart to GitHub Container Registry
+      - name: Install Helm
+        uses: azure/setup-helm@v4.3.0
+        with:
+          version: v3.19.1
+
+      - name: Login to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${GH_TOKEN}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Package and publish chart to GHCR
+        run: |
+          CHART_VERSION=$(grep '^version:' charts/tekton-pipeline/Chart.yaml | awk '{print $2}')
+          helm package charts/tekton-pipeline
+          helm push tekton-pipeline-${CHART_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ For latest set `app_version` to the latest tekton version from the [tekton relea
 [Helm](https://helm.sh) must be installed to use the charts.
 Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
-Once Helm is set up properly, add the repo as follows:
+Once Helm is set up properly, you can install the chart using one of the following methods:
+
+#### Method 1: GitHub Pages Repository
+
+Add the repo as follows:
 
 ```bash
 helm repo add cdf https://cdfoundation.github.io/tekton-helm-chart/
@@ -55,6 +59,14 @@ you can then do
 
 ```bash
 helm search repo tekton
+```
+
+#### Method 2: GHCR OCI Registry
+
+The chart is also available as an OCI artifact in GitHub Container Registry:
+
+```bash
+helm install tekton-pipeline oci://ghcr.io/cdfoundation/charts/tekton-pipeline --version <version>
 ```
 
 The chart installs resources into the `tekton-pipelines` namespace

--- a/charts/tekton-pipeline/Chart.yaml
+++ b/charts/tekton-pipeline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tekton Pipelines
 name: tekton-pipeline
-version: 1.12.1
-appVersion: 1.12.0
+version: 1.12.2
+appVersion: 1.12.2
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/cdfoundation/tekton-helm-chart

--- a/charts/tekton-pipeline/Chart.yaml
+++ b/charts/tekton-pipeline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tekton Pipelines
 name: tekton-pipeline
-version: 1.12.0
+version: 1.12.1
 appVersion: 1.12.0
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/cdfoundation/tekton-helm-chart

--- a/charts/tekton-pipeline/crds/customruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/customruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
-    version: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
+    version: "v1.12.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/pipelineruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/pipelineruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
-    version: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
+    version: "v1.12.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/pipelines.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/pipelines.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
-    version: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
+    version: "v1.12.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/stepactions.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/stepactions.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
-    version: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
+    version: "v1.12.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/taskruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/taskruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
-    version: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
+    version: "v1.12.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/tasks.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/tasks.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
-    version: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
+    version: "v1.12.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/verificationpolicies.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/verificationpolicies.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
-    version: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
+    version: "v1.12.2"
 spec:
   group: tekton.dev
   versions:

--- a/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
+++ b/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
@@ -25,4 +25,4 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace we still can have access to
   # this ConfigMap.
-  version: "v1.12.0"
+  version: "v1.12.2"

--- a/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
@@ -6,9 +6,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: events
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.12.0
-    pipeline.tekton.dev/release: v1.12.0
-    version: v1.12.0
+    app.kubernetes.io/version: v1.12.2
+    pipeline.tekton.dev/release: v1.12.2
+    version: v1.12.2
   name: tekton-events-controller
 spec:
   replicas: 1
@@ -26,9 +26,9 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: events
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.12.0
-        pipeline.tekton.dev/release: v1.12.0
-        version: v1.12.0
+        app.kubernetes.io/version: v1.12.2
+        pipeline.tekton.dev/release: v1.12.2
+        version: v1.12.2
     spec:
       affinity:
         nodeAffinity:

--- a/charts/tekton-pipeline/templates/tekton-events-controller-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: events
     app.kubernetes.io/component: events
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.0"
+    app.kubernetes.io/version: "v1.12.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-events-controller
-    version: "v1.12.0"
+    version: "v1.12.2"
   name: tekton-events-controller
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.2
       {{- with .Values.controller.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v1.12.0
-    version: v1.12.0
+    pipeline.tekton.dev/release: v1.12.2
+    version: v1.12.2
   name: tekton-pipelines-controller
 spec:
   replicas: 1
@@ -34,12 +34,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: controller
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.12.0
+        app.kubernetes.io/version: v1.12.2
           {{- with .Values.controller.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v1.12.0
-        version: v1.12.0
+        pipeline.tekton.dev/release: v1.12.2
+        version: v1.12.2
     spec:
       affinity:
           {{- with .Values.controller.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.0"
+    app.kubernetes.io/version: "v1.12.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-controller
-    version: "v1.12.0"
+    version: "v1.12.2"
   name: tekton-pipelines-controller
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -6,9 +6,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.12.0
-    pipeline.tekton.dev/release: v1.12.0
-    version: v1.12.0
+    app.kubernetes.io/version: v1.12.2
+    pipeline.tekton.dev/release: v1.12.2
+    version: v1.12.2
   name: tekton-pipelines-remote-resolvers
 spec:
   replicas: 1
@@ -26,9 +26,9 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: resolvers
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.12.0
-        pipeline.tekton.dev/release: v1.12.0
-        version: v1.12.0
+        app.kubernetes.io/version: v1.12.2
+        pipeline.tekton.dev/release: v1.12.2
+        version: v1.12.2
     spec:
       affinity:
           {{- with .Values.remoteresolver.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-svc.yaml
@@ -18,13 +18,13 @@ metadata:
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/component: resolvers
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.0"
+    app.kubernetes.io/version: "v1.12.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-remote-resolvers
-    version: "v1.12.0"
+    version: "v1.12.2"
   name: tekton-pipelines-remote-resolvers
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.12.0
+    app.kubernetes.io/version: v1.12.2
       {{- with .Values.webhook.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v1.12.0
-    version: v1.12.0
+    pipeline.tekton.dev/release: v1.12.2
+    version: v1.12.2
   name: tekton-pipelines-webhook
 spec:
   selector:
@@ -28,12 +28,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: webhook
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.12.0
+        app.kubernetes.io/version: v1.12.2
           {{- with .Values.webhook.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v1.12.0
-        version: v1.12.0
+        pipeline.tekton.dev/release: v1.12.2
+        version: v1.12.2
     spec:
       affinity:
           {{- with .Values.webhook.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
@@ -20,12 +20,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.0"
+    app.kubernetes.io/version: "v1.12.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v1.12.0"
+    version: "v1.12.2"
 spec:
   minReplicas: 1
   maxReplicas: 5

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.0"
+    app.kubernetes.io/version: "v1.12.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-webhook
-    version: "v1.12.0"
+    version: "v1.12.2"
   name: tekton-pipelines-webhook
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
+++ b/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
@@ -20,5 +20,5 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
     # The data is populated at install time.

--- a/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.0"
+    pipeline.tekton.dev/release: "v1.12.2"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -25,13 +25,13 @@ serviceaccount:
 # Values for tekton-pipelines-controller
 controller:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.12.0@sha256:8d5f900677386b8fe5371429e9c1461b25de47e5e34736c7f99e82e2c279ebbc
+    image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.12.2@sha256:76728a24a606d6f2205ae50e31bb08a1b185b60a2456fe7d9c73c175047ce5aa
     labels: {}
   images:
-    entrypoint: "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.12.0@sha256:3ec960b07abd85604242e146092e72f11be8787452c2a20d12a37fdee4a666e2"
-    nop: "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.12.0@sha256:f89fb760b05fdef6895290e524d992b66ede72546622d5028b0406a9bea36d2f"
-    sidecarlogresults: "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.12.0@sha256:8b61bdcad62a99e7b15f9dc92690ea39f49be2c5a1c9f428a0aac712f349543d"
-    workingdirinit: "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.12.0@sha256:11031cbed2b8ddbb5af0947a5e0c997ba7cd3da5f309ddfa76e58f5418868d71"
+    entrypoint: "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.12.2@sha256:7def477fc1d36ab1d38f2872dfeaf62cc43c0ebacf117eed62caa39fea0c7db2"
+    nop: "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.12.2@sha256:23a7308656c90b9ef73b01ddc03ab19a80282a66a9cd505f97540e75213e4f9b"
+    sidecarlogresults: "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.12.2@sha256:20f72f06804a52ba851f41fc06644d750871769c3e94e0b99e940a0f837a1368"
+    workingdirinit: "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.12.2@sha256:fd8aeb5a1a73757ee36713880bd712b3d8a6c5f94f963e34193a7fbd32c77c65"
     shellImage: "cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791"
     shellImageWin: "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6"
   pod:
@@ -55,7 +55,7 @@ controller:
 # Values for tekton-pipelines-webhook
 webhook:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.12.0@sha256:1e4eded1773f6fa8ec67c9348f84bed0d39666a9698ebd1ffb4eaed88b38f7d4
+    image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.12.2@sha256:12d542c81d166c26546b0cad60fa1e2a7d5c4b5dc9ad30612d3feb939ce1d12c
     labels: {}
   pod:
     labels: {}
@@ -76,7 +76,7 @@ webhook:
 # Values to amend tekton-pipelines-remote-resolvers
 remoteresolver:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.12.0@sha256:b1f06197342ed946b23efd1ce124d7c17d50678b461733a6cc0912b07a4943e7
+    image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.12.2@sha256:6047be2af74b86129eb22b76ca908754c932208573e0a62a5f498da99b552e6a
   affinity: {}
   tolerations: []
   nodeSelector: {}
@@ -90,7 +90,7 @@ remoteresolver:
 # Values for tekton-events-controller
 eventscontroller:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.12.0@sha256:d5d5869215a58fea01ce627d605786090949a324969102ab1fd25716adde10e9
+    image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.12.2@sha256:facd8325f8cf78f63d5e687faaed5cc2c0d4111da72464083ceff00a7e0b3c56
 # configuration to put in the config-defaults ConfigMap
 configDefaults:
   _example: |


### PR DESCRIPTION
### Changes
* Update chart and app to v1.12.2
* Add steps to additionally publish Helm charts to ghcr.io

### Context

Implementation of issue https://github.com/cdfoundation/tekton-helm-chart/issues/84 to support OCI-based charts.

Bump minor chart and app versions to publish this change

