### PR TITLE
feat: make all images configurable via values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ fetch:
 	mkdir -p ${CHART_DIR}/templates
 	mkdir -p $(CHART_DIR)/crds
 ifeq ($(CHART_VERSION),latest)
-	curl -sS https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml > ${CHART_DIR}/templates/resource.yaml
+	curl -sSL https://github.com/tektoncd/pipeline/releases/latest/download/release.yaml > ${CHART_DIR}/templates/resource.yaml
 else
-	curl -sS https://storage.googleapis.com/tekton-releases/pipeline/previous/v${CHART_VERSION}/release.yaml > ${CHART_DIR}/templates/resource.yaml
+	curl -sSL https://github.com/tektoncd/pipeline/releases/download/v${CHART_VERSION}/release.yaml > ${CHART_DIR}/templates/resource.yaml
 endif
 	jx gitops split -d ${CHART_DIR}/templates
 	jx gitops rename -d ${CHART_DIR}/templates
@@ -61,7 +61,7 @@ endif
 	find $(CHART_DIR)/templates -type f -name "*aggregate*clusterrole.yaml" -exec sh -c 'sed -i.bak "1s/{{- if .Values.createClusterRoles }}/{{- if and .Values.createAggregateRoles .Values.createClusterRoles }}/" "$$1" && rm "$$1.bak"' _ {} \;
 	cp src/templates/* ${CHART_DIR}/templates
 ifneq ($(CHART_VERSION),latest)
-	sed -i.bak "s/^appVersion:.*/appVersion: ${CHART_VERSION}/" ${CHART_DIR}/Chart.yaml
+	sed -i.bak "s/^appVersion:.*/appVersion: ${CHART_VERSION}/" ${CHART_DIR}/Chart.yaml && rm ${CHART_DIR}/Chart.yaml.bak
 endif
 
 version:

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ endif
 	yq -i '.data = null' $(CHART_DIR)/templates/git-resolver-config-cm.yaml
 	# Remove image: from tekton-pipelines-controller-deploy
 	yq -i 'del(.spec.template.spec.containers[].image)' $(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml
+	# Remove image: from tekton-pipelines-webhook-deploy
+	yq -i 'del(.spec.template.spec.containers[].image)' $(CHART_DIR)/templates/tekton-pipelines-webhook-deploy.yaml
+	# Remove image: from tekton-pipelines-remote-resolvers-deploy
+	yq -i 'del(.spec.template.spec.containers[].image)' $(CHART_DIR)/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+	# Remove image: from tekton-events-controller-deploy
+	yq -i 'del(.spec.template.spec.containers[].image)' $(CHART_DIR)/templates/tekton-events-controller-deploy.yaml
 	# Make node affinity configurable
 	yq -i '.webhook.affinity.nodeAffinity = load("$(CHART_DIR)/templates/tekton-pipelines-webhook-deploy.yaml").spec.template.spec.affinity.nodeAffinity' $(CHART_DIR)/values.yaml
 	yq -i 'del(.spec.template.spec.affinity.nodeAffinity)' $(CHART_DIR)/templates/tekton-pipelines-webhook-deploy.yaml

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,17 @@ endif
 	# Move content of data: from git-resolver-config-cm.yaml to gitResolverConfig: in values.yaml
 	yq -i '.gitResolverConfig = load("$(CHART_DIR)/templates/git-resolver-config-cm.yaml").data' $(CHART_DIR)/values.yaml
 	yq -i '.data = null' $(CHART_DIR)/templates/git-resolver-config-cm.yaml
+	# Extract image values from release into values.yaml
+	yq -i '.controller.deployment.image = load("$(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml").spec.template.spec.containers[0].image' $(CHART_DIR)/values.yaml
+	yq -i '.controller.images.entrypoint = (load("$(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml").spec.template.spec.containers[0].args | . as $$a | (to_entries[] | select(.value == "-entrypoint-image") | .key + 1) as $$i | $$a[$$i])' $(CHART_DIR)/values.yaml
+	yq -i '.controller.images.nop = (load("$(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml").spec.template.spec.containers[0].args | . as $$a | (to_entries[] | select(.value == "-nop-image") | .key + 1) as $$i | $$a[$$i])' $(CHART_DIR)/values.yaml
+	yq -i '.controller.images.sidecarlogresults = (load("$(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml").spec.template.spec.containers[0].args | . as $$a | (to_entries[] | select(.value == "-sidecarlogresults-image") | .key + 1) as $$i | $$a[$$i])' $(CHART_DIR)/values.yaml
+	yq -i '.controller.images.workingdirinit = (load("$(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml").spec.template.spec.containers[0].args | . as $$a | (to_entries[] | select(.value == "-workingdirinit-image") | .key + 1) as $$i | $$a[$$i])' $(CHART_DIR)/values.yaml
+	yq -i '.controller.images.shellImage = (load("$(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml").spec.template.spec.containers[0].args | . as $$a | (to_entries[] | select(.value == "-shell-image") | .key + 1) as $$i | $$a[$$i])' $(CHART_DIR)/values.yaml
+	yq -i '.controller.images.shellImageWin = (load("$(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml").spec.template.spec.containers[0].args | . as $$a | (to_entries[] | select(.value == "-shell-image-win") | .key + 1) as $$i | $$a[$$i])' $(CHART_DIR)/values.yaml
+	yq -i '.webhook.deployment.image = load("$(CHART_DIR)/templates/tekton-pipelines-webhook-deploy.yaml").spec.template.spec.containers[0].image' $(CHART_DIR)/values.yaml
+	yq -i '.remoteresolver.deployment.image = load("$(CHART_DIR)/templates/tekton-pipelines-remote-resolvers-deploy.yaml").spec.template.spec.containers[0].image' $(CHART_DIR)/values.yaml
+	yq -i '.eventscontroller.deployment.image = load("$(CHART_DIR)/templates/tekton-events-controller-deploy.yaml").spec.template.spec.containers[0].image' $(CHART_DIR)/values.yaml
 	# Remove image: from tekton-pipelines-controller-deploy
 	yq -i 'del(.spec.template.spec.containers[].image)' $(CHART_DIR)/templates/tekton-pipelines-controller-deploy.yaml
 	# Remove image: from tekton-pipelines-webhook-deploy

--- a/charts/tekton-pipeline/Chart.yaml
+++ b/charts/tekton-pipeline/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 description: A Helm chart for Tekton Pipelines
 name: tekton-pipeline
 version: 1.9.1
-appVersion: 1.9.1
+appVersion: 1.9.2
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/cdfoundation/tekton-helm-chart

--- a/charts/tekton-pipeline/Chart.yaml
+++ b/charts/tekton-pipeline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tekton Pipelines
 name: tekton-pipeline
-version: 1.9.1
+version: 1.9.2
 appVersion: 1.9.2
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/cdfoundation/tekton-helm-chart

--- a/charts/tekton-pipeline/crds/customruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/customruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
-    version: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
+    version: "v1.9.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/pipelineruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/pipelineruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
-    version: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
+    version: "v1.9.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/pipelines.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/pipelines.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
-    version: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
+    version: "v1.9.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/stepactions.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/stepactions.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
-    version: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
+    version: "v1.9.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/taskruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/taskruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
-    version: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
+    version: "v1.9.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/tasks.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/tasks.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
-    version: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
+    version: "v1.9.2"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/verificationpolicies.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/verificationpolicies.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
-    version: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
+    version: "v1.9.2"
 spec:
   group: tekton.dev
   versions:

--- a/charts/tekton-pipeline/kustomization.yaml
+++ b/charts/tekton-pipeline/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - templates/feature-flags-cm.yaml
 - templates/git-resolver-config-cm.yaml
 - templates/tekton-pipelines-remote-resolvers-deploy.yaml
+- templates/tekton-events-controller-deploy.yaml
 
 patchesStrategicMerge:
 - patches/tekton-pipelines-controller-deploy.yaml
@@ -16,3 +17,4 @@ patchesStrategicMerge:
 - patches/feature-flags-cm.yaml
 - patches/git-resolver-config-cm.yaml
 - patches/tekton-pipelines-remote-resolvers-deploy.yaml
+- patches/tekton-events-controller-deploy.yaml

--- a/charts/tekton-pipeline/patches/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-events-controller-deploy.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-events-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: tekton-events-controller
+      helmTemplateRemoveMe: |
+        image: {{ .Values.eventscontroller.deployment.image }}

--- a/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
@@ -29,6 +29,19 @@ spec:
           {{- end }}
       containers:
       - name: tekton-pipelines-controller
+        args:
+        - -entrypoint-image
+        - '{{ .Values.controller.images.entrypoint }}'
+        - -nop-image
+        - '{{ .Values.controller.images.nop }}'
+        - -sidecarlogresults-image
+        - '{{ .Values.controller.images.sidecarlogresults }}'
+        - -workingdirinit-image
+        - '{{ .Values.controller.images.workingdirinit }}'
+        - -shell-image
+        - '{{ .Values.controller.images.shellImage }}'
+        - -shell-image-win
+        - '{{ .Values.controller.images.shellImageWin }}'
         resources:
           helmTemplateRemoveMe: |
             {{- toYaml  .Values.controller.resources |  nindent 10 }}

--- a/charts/tekton-pipeline/patches/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -27,3 +27,5 @@ spec:
               {{- with .Values.remoteresolver.resources }}
                 {{- toYaml . | trim | nindent 10 }}
               {{- end }}
+      helmTemplateRemoveMe: |
+        image: {{ .Values.remoteresolver.deployment.image }}

--- a/charts/tekton-pipeline/patches/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-webhook-deploy.yaml
@@ -27,6 +27,8 @@ spec:
         - secretRef:
             name: "{{ .Values.webhook.envFromSecret }}"
             optional: true
+      helmTemplateRemoveMe: |
+        image: {{ .Values.webhook.deployment.image }}
       nodeSelector:
         helmTemplateRemoveMe: |
           {{- with .Values.webhook.nodeSelector }}

--- a/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
+++ b/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
@@ -25,4 +25,4 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace we still can have access to
   # this ConfigMap.
-  version: "v1.9.1"
+  version: "v1.9.2"

--- a/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
@@ -1,133 +1,111 @@
-# Copyright 2023 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tekton-events-controller
   labels:
-    app.kubernetes.io/name: events
     app.kubernetes.io/component: events
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/name: events
     app.kubernetes.io/part-of: tekton-pipelines
-    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.1"
-    # labels below are related to istio and should not be used for resource lookup
-    version: "v1.9.1"
+    app.kubernetes.io/version: v1.9.1
+    pipeline.tekton.dev/release: v1.9.1
+    version: v1.9.1
+  name: tekton-events-controller
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: events
       app.kubernetes.io/component: events
       app.kubernetes.io/instance: default
+      app.kubernetes.io/name: events
       app.kubernetes.io/part-of: tekton-pipelines
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: events
+        app: tekton-events-controller
         app.kubernetes.io/component: events
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v1.9.1"
+        app.kubernetes.io/name: events
         app.kubernetes.io/part-of: tekton-pipelines
-        # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v1.9.1"
-        # labels below are related to istio and should not be used for resource lookup
-        app: tekton-events-controller
-        version: "v1.9.1"
+        app.kubernetes.io/version: v1.9.1
+        pipeline.tekton.dev/release: v1.9.1
+        version: v1.9.1
     spec:
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: NotIn
-                    values:
-                      - windows
-      serviceAccountName: tekton-events-controller
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
       containers:
-        - name: tekton-events-controller
-          image: {{ .Values.eventscontroller.deployment.image }}
-          args: []
-          volumeMounts:
-            - name: config-logging
-              mountPath: /etc/config-logging
-            - name: config-registry-cert
-              mountPath: /etc/config-registry-cert
-          env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: KUBERNETES_MIN_VERSION
-              value: "v1.28.0"
-            # If you are changing these names, you will also need to update
-            # the controller's Role in 200-role.yaml to include the new
-            # values in the "configmaps" "get" rule.
-            - name: CONFIG_DEFAULTS_NAME
-              value: config-defaults
-            - name: CONFIG_LOGGING_NAME
-              value: config-logging
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: config-observability
-            - name: CONFIG_LEADERELECTION_NAME
-              value: config-leader-election-events
-            - name: SSL_CERT_FILE
-              value: /etc/config-registry-cert/cert
-            - name: SSL_CERT_DIR
-              value: /etc/ssl/certs
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - "ALL"
-            # User 65532 is the nonroot user ID
-            runAsUser: 65532
-            runAsGroup: 65532
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-          ports:
-            - name: metrics
-              containerPort: 9090
-            - name: profiling
-              containerPort: 8008
-            - name: probes
-              containerPort: 8080
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: probes
-              scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-          readinessProbe:
-            httpGet:
-              path: /readiness
-              port: probes
-              scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
+      - args: []
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KUBERNETES_MIN_VERSION
+          value: v1.28.0
+        - name: CONFIG_DEFAULTS_NAME
+          value: config-defaults
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-events
+        - name: SSL_CERT_FILE
+          value: /etc/config-registry-cert/cert
+        - name: SSL_CERT_DIR
+          value: /etc/ssl/certs
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        name: tekton-events-controller
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        - containerPort: 8080
+          name: probes
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: probes
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/config-logging
+          name: config-logging
+        - mountPath: /etc/config-registry-cert
+          name: config-registry-cert
+        image: {{ .Values.eventscontroller.deployment.image }}
+      serviceAccountName: tekton-events-controller
       volumes:
-        - name: config-logging
-          configMap:
-            name: config-logging
-        - name: config-registry-cert
-          configMap:
-            name: config-registry-cert
+      - configMap:
+          name: config-logging
+        name: config-logging
+      - configMap:
+          name: config-registry-cert
+        name: config-registry-cert

--- a/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
@@ -6,9 +6,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: events
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.9.1
-    pipeline.tekton.dev/release: v1.9.1
-    version: v1.9.1
+    app.kubernetes.io/version: v1.9.2
+    pipeline.tekton.dev/release: v1.9.2
+    version: v1.9.2
   name: tekton-events-controller
 spec:
   replicas: 1
@@ -26,9 +26,9 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: events
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.9.1
-        pipeline.tekton.dev/release: v1.9.1
-        version: v1.9.1
+        app.kubernetes.io/version: v1.9.2
+        pipeline.tekton.dev/release: v1.9.2
+        version: v1.9.2
     spec:
       affinity:
         nodeAffinity:

--- a/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: tekton-events-controller
       containers:
         - name: tekton-events-controller
-          image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.9.1@sha256:c61afad2301e4c33530772dcec0fd8a890725e46c2c729edf4a9e84244a938b6
+          image: {{ .Values.eventscontroller.deployment.image }}
           args: []
           volumeMounts:
             - name: config-logging

--- a/charts/tekton-pipeline/templates/tekton-events-controller-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: events
     app.kubernetes.io/component: events
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.9.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-events-controller
-    version: "v1.9.1"
+    version: "v1.9.2"
   name: tekton-events-controller
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -59,17 +59,17 @@ spec:
       containers:
       - args:
         - -entrypoint-image
-        - ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.9.1@sha256:b854e1010e58455cb5ee41e365a3b768ccdc463e7e4446c72cf885be9abbda14
+        - {{ .Values.controller.images.entrypoint }}
         - -nop-image
-        - ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.9.1@sha256:708d9fbf6a7cfeb988ca7dd7b2e2cae3e5870a62a3a77c27028514f4d8c90616
+        - {{ .Values.controller.images.nop }}
         - -sidecarlogresults-image
-        - ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.9.1@sha256:5c7dafc80deaf8acc32f62420719f0ff231f3409b060bf7f5bdc8a176c76d392
+        - {{ .Values.controller.images.sidecarlogresults }}
         - -workingdirinit-image
-        - ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.9.1@sha256:2c547382ce634d1a081d862b92e4476d400d03ed131a1a39123e4ac28f786bd1
+        - {{ .Values.controller.images.workingdirinit }}
         - -shell-image
-        - cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791
+        - {{ .Values.controller.images.shellImage }}
         - -shell-image-win
-        - mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6
+        - {{ .Values.controller.images.shellImageWin }}
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.9.1
+    app.kubernetes.io/version: v1.9.2
       {{- with .Values.controller.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v1.9.1
-    version: v1.9.1
+    pipeline.tekton.dev/release: v1.9.2
+    version: v1.9.2
   name: tekton-pipelines-controller
 spec:
   replicas: 1
@@ -34,12 +34,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: controller
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.9.1
+        app.kubernetes.io/version: v1.9.2
           {{- with .Values.controller.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v1.9.1
-        version: v1.9.1
+        pipeline.tekton.dev/release: v1.9.2
+        version: v1.9.2
     spec:
       affinity:
           {{- with .Values.controller.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -59,17 +59,17 @@ spec:
       containers:
       - args:
         - -entrypoint-image
-        - {{ .Values.controller.images.entrypoint }}
+        - '{{ .Values.controller.images.entrypoint }}'
         - -nop-image
-        - {{ .Values.controller.images.nop }}
+        - '{{ .Values.controller.images.nop }}'
         - -sidecarlogresults-image
-        - {{ .Values.controller.images.sidecarlogresults }}
+        - '{{ .Values.controller.images.sidecarlogresults }}'
         - -workingdirinit-image
-        - {{ .Values.controller.images.workingdirinit }}
+        - '{{ .Values.controller.images.workingdirinit }}'
         - -shell-image
-        - {{ .Values.controller.images.shellImage }}
+        - '{{ .Values.controller.images.shellImage }}'
         - -shell-image-win
-        - {{ .Values.controller.images.shellImageWin }}
+        - '{{ .Values.controller.images.shellImageWin }}'
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.9.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-controller
-    version: "v1.9.1"
+    version: "v1.9.2"
   name: tekton-pipelines-controller
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -82,7 +82,6 @@ spec:
           value: ""
         - name: ARTIFACT_HUB_API
           value: https://artifacthub.io/
-        image: {{ .Values.remoteresolver.deployment.image }}
         name: controller
         ports:
         - containerPort: 9090
@@ -108,6 +107,7 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp-clone-volume
+        image: {{ .Values.remoteresolver.deployment.image }}
       nodeSelector:
           {{- with .Values.remoteresolver.nodeSelector }}
             {{- toYaml . |  nindent 8 }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -82,7 +82,7 @@ spec:
           value: ""
         - name: ARTIFACT_HUB_API
           value: https://artifacthub.io/
-        image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.9.1@sha256:99d67acd22e5a1c8d7655ab03929eb898536c3f54adc975cdc328aaa9a98685d
+        image: {{ .Values.remoteresolver.deployment.image }}
         name: controller
         ports:
         - containerPort: 9090

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -6,9 +6,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.9.1
-    pipeline.tekton.dev/release: v1.9.1
-    version: v1.9.1
+    app.kubernetes.io/version: v1.9.2
+    pipeline.tekton.dev/release: v1.9.2
+    version: v1.9.2
   name: tekton-pipelines-remote-resolvers
 spec:
   replicas: 1
@@ -26,9 +26,9 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: resolvers
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.9.1
-        pipeline.tekton.dev/release: v1.9.1
-        version: v1.9.1
+        app.kubernetes.io/version: v1.9.2
+        pipeline.tekton.dev/release: v1.9.2
+        version: v1.9.2
     spec:
       affinity:
           {{- with .Values.remoteresolver.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-svc.yaml
@@ -18,13 +18,13 @@ metadata:
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/component: resolvers
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.9.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-remote-resolvers
-    version: "v1.9.1"
+    version: "v1.9.2"
   name: tekton-pipelines-remote-resolvers
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.9.1
+    app.kubernetes.io/version: v1.9.2
       {{- with .Values.webhook.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v1.9.1
-    version: v1.9.1
+    pipeline.tekton.dev/release: v1.9.2
+    version: v1.9.2
   name: tekton-pipelines-webhook
 spec:
   selector:
@@ -28,12 +28,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: webhook
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.9.1
+        app.kubernetes.io/version: v1.9.2
           {{- with .Values.webhook.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v1.9.1
-        version: v1.9.1
+        pipeline.tekton.dev/release: v1.9.2
+        version: v1.9.2
     spec:
       affinity:
           {{- with .Values.webhook.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -82,7 +82,7 @@ spec:
         - secretRef:
             name: '{{ .Values.webhook.envFromSecret }}'
             optional: true
-        image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.9.1@sha256:9adf822e356b9272011eab5539140afe173b19346fb6a1733ff44085221d99db
+        image: {{ .Values.webhook.deployment.image }}
         livenessProbe:
           httpGet:
             path: /health

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -82,7 +82,6 @@ spec:
         - secretRef:
             name: '{{ .Values.webhook.envFromSecret }}'
             optional: true
-        image: {{ .Values.webhook.deployment.image }}
         livenessProbe:
           httpGet:
             path: /health
@@ -127,6 +126,7 @@ spec:
           runAsUser: 65532
           seccompProfile:
             type: RuntimeDefault
+        image: {{ .Values.webhook.deployment.image }}
       nodeSelector:
           {{- with .Values.webhook.nodeSelector }}
             {{- toYaml . |  nindent 8 }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
@@ -20,12 +20,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.9.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v1.9.1"
+    version: "v1.9.2"
 spec:
   minReplicas: 1
   maxReplicas: 5

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.9.2"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-webhook
-    version: "v1.9.1"
+    version: "v1.9.2"
   name: tekton-pipelines-webhook
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
+++ b/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
@@ -20,5 +20,5 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
     # The data is populated at install time.

--- a/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.1"
+    pipeline.tekton.dev/release: "v1.9.2"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -25,13 +25,13 @@ serviceaccount:
 # Values for tekton-pipelines-controller
 controller:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.9.1@sha256:84eafd35dddc1f3da54ee1790c6504061f4e6a0ed217bf3d6542a4ef4296f03d
+    image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.9.2@sha256:a6833aa4bd352d33335d4a9329fce13e44407773c703d71099aa07d0f2846826
     labels: {}
   images:
-    entrypoint: "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.9.1@sha256:b854e1010e58455cb5ee41e365a3b768ccdc463e7e4446c72cf885be9abbda14"
-    nop: "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.9.1@sha256:708d9fbf6a7cfeb988ca7dd7b2e2cae3e5870a62a3a77c27028514f4d8c90616"
-    sidecarlogresults: "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.9.1@sha256:5c7dafc80deaf8acc32f62420719f0ff231f3409b060bf7f5bdc8a176c76d392"
-    workingdirinit: "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.9.1@sha256:2c547382ce634d1a081d862b92e4476d400d03ed131a1a39123e4ac28f786bd1"
+    entrypoint: "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.9.2@sha256:f9b98c1f7fc4a747dc0d118def8bbde58c81da31c5d80e2d70f7f67b2cf16982"
+    nop: "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.9.2@sha256:5a125c13f79fe80d09eca799293efa775ba37aed1322a18a49f11052401dac21"
+    sidecarlogresults: "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.9.2@sha256:0623a2085539a1aac38c2b89da59cc544839c7085684861e24737068a80acaa0"
+    workingdirinit: "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.9.2@sha256:57f4e62abb27e460ec1cef38c911ab9b53ca5f3757b88828e8d2c24e5718112e"
     shellImage: "cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791"
     shellImageWin: "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6"
   pod:
@@ -55,7 +55,7 @@ controller:
 # Values for tekton-pipelines-webhook
 webhook:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.9.1@sha256:9adf822e356b9272011eab5539140afe173b19346fb6a1733ff44085221d99db
+    image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.9.2@sha256:60189c3482571001d2be2f3cb5b9ca41a10b885fe12e743847ebe0f5ccfb788a
     labels: {}
   pod:
     labels: {}
@@ -76,7 +76,7 @@ webhook:
 # Values to amend tekton-pipelines-remote-resolvers
 remoteresolver:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.9.1@sha256:99d67acd22e5a1c8d7655ab03929eb898536c3f54adc975cdc328aaa9a98685d
+    image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.9.2@sha256:e83af2b69c5546ad6bfca67c2903ce92ef6012c1b3bcab54b5c7b38121228a58
   affinity: {}
   tolerations: []
   nodeSelector: {}
@@ -90,7 +90,7 @@ remoteresolver:
 # Values for tekton-events-controller
 eventscontroller:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.9.1@sha256:c61afad2301e4c33530772dcec0fd8a890725e46c2c729edf4a9e84244a938b6
+    image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.9.2@sha256:3cfd35631998087b2eafb40705fe9e0fae115e5f3c4aaec56c942e179fd6c14e
 # configuration to put in the config-defaults ConfigMap
 configDefaults:
   _example: |

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -28,12 +28,12 @@ controller:
     image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.9.1@sha256:84eafd35dddc1f3da54ee1790c6504061f4e6a0ed217bf3d6542a4ef4296f03d
     labels: {}
   images:
-    entrypoint: ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.9.1@sha256:b854e1010e58455cb5ee41e365a3b768ccdc463e7e4446c72cf885be9abbda14
-    nop: ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.9.1@sha256:708d9fbf6a7cfeb988ca7dd7b2e2cae3e5870a62a3a77c27028514f4d8c90616
-    sidecarlogresults: ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.9.1@sha256:5c7dafc80deaf8acc32f62420719f0ff231f3409b060bf7f5bdc8a176c76d392
-    workingdirinit: ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.9.1@sha256:2c547382ce634d1a081d862b92e4476d400d03ed131a1a39123e4ac28f786bd1
-    shellImage: cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791
-    shellImageWin: mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6
+    entrypoint: "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.9.1@sha256:b854e1010e58455cb5ee41e365a3b768ccdc463e7e4446c72cf885be9abbda14"
+    nop: "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.9.1@sha256:708d9fbf6a7cfeb988ca7dd7b2e2cae3e5870a62a3a77c27028514f4d8c90616"
+    sidecarlogresults: "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.9.1@sha256:5c7dafc80deaf8acc32f62420719f0ff231f3409b060bf7f5bdc8a176c76d392"
+    workingdirinit: "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.9.1@sha256:2c547382ce634d1a081d862b92e4476d400d03ed131a1a39123e4ac28f786bd1"
+    shellImage: "cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791"
+    shellImageWin: "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6"
   pod:
     labels: {}
     annotations: {}

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -27,6 +27,13 @@ controller:
   deployment:
     image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.9.1@sha256:84eafd35dddc1f3da54ee1790c6504061f4e6a0ed217bf3d6542a4ef4296f03d
     labels: {}
+  images:
+    entrypoint: ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.9.1@sha256:b854e1010e58455cb5ee41e365a3b768ccdc463e7e4446c72cf885be9abbda14
+    nop: ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.9.1@sha256:708d9fbf6a7cfeb988ca7dd7b2e2cae3e5870a62a3a77c27028514f4d8c90616
+    sidecarlogresults: ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.9.1@sha256:5c7dafc80deaf8acc32f62420719f0ff231f3409b060bf7f5bdc8a176c76d392
+    workingdirinit: ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.9.1@sha256:2c547382ce634d1a081d862b92e4476d400d03ed131a1a39123e4ac28f786bd1
+    shellImage: cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791
+    shellImageWin: mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6
   pod:
     labels: {}
     annotations: {}
@@ -48,6 +55,7 @@ controller:
 # Values for tekton-pipelines-webhook
 webhook:
   deployment:
+    image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.9.1@sha256:9adf822e356b9272011eab5539140afe173b19346fb6a1733ff44085221d99db
     labels: {}
   pod:
     labels: {}
@@ -67,6 +75,8 @@ webhook:
   nodeSelector: {}
 # Values to amend tekton-pipelines-remote-resolvers
 remoteresolver:
+  deployment:
+    image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.9.1@sha256:99d67acd22e5a1c8d7655ab03929eb898536c3f54adc975cdc328aaa9a98685d
   affinity: {}
   tolerations: []
   nodeSelector: {}
@@ -77,6 +87,10 @@ remoteresolver:
     limits:
       cpu: 1000m
       memory: 4Gi
+# Values for tekton-events-controller
+eventscontroller:
+  deployment:
+    image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.9.1@sha256:c61afad2301e4c33530772dcec0fd8a890725e46c2c729edf4a9e84244a938b6
 # configuration to put in the config-defaults ConfigMap
 configDefaults:
   _example: |


### PR DESCRIPTION
## Summary

- All hardcoded image references across Tekton pipeline deployments are now overridable via `values.yaml`, enabling private registry usage without patching templates
- Image changes are driven through the `make fetch` pipeline (Makefile + kustomize patches) rather than direct template edits, per project convention

## Changes

**values.yaml**
- Added `controller.images` block for the 6 sidecar/utility images passed as controller args (`entrypoint`, `nop`, `sidecarlogresults`, `workingdirinit`, `shellImage`, `shellImageWin`)
- Added `webhook.deployment.image`, `remoteresolver.deployment.image`, and `eventscontroller.deployment.image`

**Makefile**
- Switched release download source from GCS bucket to GitHub Releases — GCS only has up to v1.6.0; v1.9.1+ are published to GitHub only
- Added `yq del` commands to strip hardcoded `image:` from webhook, remote-resolvers, and events-controller templates (consistent with existing controller handling)
- Fixed `sed -i.bak` leaving `Chart.yaml.bak` behind by cleaning it up inline

**kustomization.yaml + patches**
- Added `tekton-events-controller-deploy.yaml` to kustomize resources and patches
- Updated controller patch to replace the full `args` list with helm template values via strategic merge
- Added `helmTemplateRemoveMe` image injection to webhook, remote-resolvers, and events-controller patches

## Test plan

- [ ] Run `make fetch CHART_VERSION=1.9.1` and verify templates are regenerated with helm template references intact
- [ ] Run `helm template` and confirm all 4 deployments render with correct image values
- [ ] Override an image via `--set` and verify it takes effect