### PR TITLE
chore(bump): upgrade Tekton pipeline manifests to v1.12.0

### DIFF
--- a/charts/tekton-pipeline/Chart.yaml
+++ b/charts/tekton-pipeline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tekton Pipelines
 name: tekton-pipeline
-version: 1.9.2
-appVersion: 1.9.2
+version: 1.12.0
+appVersion: 1.12.0
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/cdfoundation/tekton-helm-chart

--- a/charts/tekton-pipeline/crds/customruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/customruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
-    version: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
+    version: "v1.12.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/pipelineruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/pipelineruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
-    version: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
+    version: "v1.12.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -193,7 +193,9 @@ spec:
                           - name
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -246,6 +248,42 @@ spec:
                                     type: string
                                   fieldPath:
                                     description: Path of the field to select in the specified API version.
+                                    type: string
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                type: object
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                    default: false
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
                                     type: string
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -409,9 +447,10 @@ spec:
                           operator:
                             description: |-
                               Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                               Exists is equivalent to wildcard for value, so that a pod can
                               tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                             type: string
                           tolerationSeconds:
                             description: |-
@@ -555,7 +594,6 @@ spec:
                               - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                               If this value is nil, the behavior is equivalent to the Honor policy.
-                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                             type: string
                           nodeTaintsPolicy:
                             description: |-
@@ -566,7 +604,6 @@ spec:
                               - Ignore: node taints are ignored. All nodes are included.
 
                               If this value is nil, the behavior is equivalent to the Ignore policy.
-                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                             type: string
                           topologyKey:
                             description: |-
@@ -715,7 +752,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -803,7 +840,7 @@ spec:
                                     Claims lists the names of resources, defined in spec.resourceClaims,
                                     that are used by this container.
 
-                                    This is an alpha field and requires enabling the
+                                    This field depends on the
                                     DynamicResourceAllocation feature gate.
 
                                     This field is immutable. It can only be set for containers.
@@ -876,7 +913,7 @@ spec:
                                     Claims lists the names of resources, defined in spec.resourceClaims,
                                     that are used by this container.
 
-                                    This is an alpha field and requires enabling the
+                                    This field depends on the
                                     DynamicResourceAllocation feature gate.
 
                                     This field is immutable. It can only be set for containers.
@@ -1008,7 +1045,9 @@ spec:
                                 - name
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 value:
                                   description: |-
@@ -1061,6 +1100,42 @@ spec:
                                           type: string
                                         fieldPath:
                                           description: Path of the field to select in the specified API version.
+                                          type: string
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                          default: false
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount containing the env file.
                                           type: string
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
@@ -1224,9 +1299,10 @@ spec:
                                 operator:
                                   description: |-
                                     Operator represents a key's relationship to the value.
-                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                     Exists is equivalent to wildcard for value, so that a pod can
                                     tolerate all taints of a particular category.
+                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                   type: string
                                 tolerationSeconds:
                                   description: |-
@@ -1370,7 +1446,6 @@ spec:
                                     - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                                     If this value is nil, the behavior is equivalent to the Honor policy.
-                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 nodeTaintsPolicy:
                                   description: |-
@@ -1381,7 +1456,6 @@ spec:
                                     - Ignore: node taints are ignored. All nodes are included.
 
                                     If this value is nil, the behavior is equivalent to the Ignore policy.
-                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 topologyKey:
                                   description: |-
@@ -1845,6 +1919,128 @@ spec:
                                                 type: string
                                             x-kubernetes-map-type: atomic
                                       x-kubernetes-list-type: atomic
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  type: object
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      type: integer
+                                      format: int32
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                    userAnnotations:
+                                      description: |-
+                                        userAnnotations allow pod authors to pass additional information to
+                                        the signer implementation.  Kubernetes does not restrict or validate this
+                                        metadata in any way.
+
+                                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                        the PodCertificateRequest objects that Kubelet creates.
+
+                                        Entries are subject to the same validation as object metadata annotations,
+                                        with the addition that all keys must be domain-prefixed. No restrictions
+                                        are placed on values, except an overall size limitation on the entire field.
+
+                                        Signers should document the keys and values they support. Signers should
+                                        deny requests that contain keys they do not recognize.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
                                 secret:
                                   description: secret information about the secret data to project
                                   type: object
@@ -2175,6 +2371,14 @@ spec:
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
                           type: boolean
+                        enableTektonOCIBundles:
+                          description: |-
+                            DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
+                            to allow deletion of PipelineRuns created before v0.62.x.
+                            This field is not used and can be removed in a future release
+                            once we're confident old PipelineRuns have been cleaned up.
+                            See issue #8359 for context.
+                          type: boolean
                         enableWaitExponentialBackoff:
                           type: boolean
                         enforceNonfalsifiability:
@@ -2414,9 +2618,7 @@ spec:
                             additionalProperties:
                               type: string
                           cloudEvents:
-                            description: |-
-                              Deprecated: Removed in v0.44.0.
-                              CloudEvents
+                            description: CloudEvents
                             type: array
                             items:
                               description: CloudEventDelivery
@@ -2546,6 +2748,14 @@ spec:
                                     type: boolean
                                   enableStepActions:
                                     description: EnableStepActions is a no-op flag since StepActions are stable
+                                    type: boolean
+                                  enableTektonOCIBundles:
+                                    description: |-
+                                      DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
+                                      to allow deletion of PipelineRuns created before v0.62.x.
+                                      This field is not used and can be removed in a future release
+                                      once we're confident old PipelineRuns have been cleaned up.
+                                      See issue #8359 for context.
                                     type: boolean
                                   enableWaitExponentialBackoff:
                                     type: boolean
@@ -2809,6 +3019,14 @@ spec:
                                           type: boolean
                                         enableStepActions:
                                           description: EnableStepActions is a no-op flag since StepActions are stable
+                                          type: boolean
+                                        enableTektonOCIBundles:
+                                          description: |-
+                                            DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
+                                            to allow deletion of PipelineRuns created before v0.62.x.
+                                            This field is not used and can be removed in a future release
+                                            once we're confident old PipelineRuns have been cleaned up.
+                                            See issue #8359 for context.
                                           type: boolean
                                         enableWaitExponentialBackoff:
                                           type: boolean
@@ -3099,7 +3317,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -3244,7 +3462,9 @@ spec:
                                 - name
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 value:
                                   description: |-
@@ -3297,6 +3517,42 @@ spec:
                                           type: string
                                         fieldPath:
                                           description: Path of the field to select in the specified API version.
+                                          type: string
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                          default: false
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount containing the env file.
                                           type: string
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
@@ -3460,9 +3716,10 @@ spec:
                                 operator:
                                   description: |-
                                     Operator represents a key's relationship to the value.
-                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                     Exists is equivalent to wildcard for value, so that a pod can
                                     tolerate all taints of a particular category.
+                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                   type: string
                                 tolerationSeconds:
                                   description: |-
@@ -3606,7 +3863,6 @@ spec:
                                     - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                                     If this value is nil, the behavior is equivalent to the Honor policy.
-                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 nodeTaintsPolicy:
                                   description: |-
@@ -3617,7 +3873,6 @@ spec:
                                     - Ignore: node taints are ignored. All nodes are included.
 
                                     If this value is nil, the behavior is equivalent to the Ignore policy.
-                                    This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                   type: string
                                 topologyKey:
                                   description: |-
@@ -3680,7 +3935,7 @@ spec:
                                     Claims lists the names of resources, defined in spec.resourceClaims,
                                     that are used by this container.
 
-                                    This is an alpha field and requires enabling the
+                                    This field depends on the
                                     DynamicResourceAllocation feature gate.
 
                                     This field is immutable. It can only be set for containers.
@@ -3752,7 +4007,7 @@ spec:
                                     Claims lists the names of resources, defined in spec.resourceClaims,
                                     that are used by this container.
 
-                                    This is an alpha field and requires enabling the
+                                    This field depends on the
                                     DynamicResourceAllocation feature gate.
 
                                     This field is immutable. It can only be set for containers.
@@ -3899,7 +4154,9 @@ spec:
                               - name
                             properties:
                               name:
-                                description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -3952,6 +4209,42 @@ spec:
                                         type: string
                                       fieldPath:
                                         description: Path of the field to select in the specified API version.
+                                        type: string
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    type: object
+                                    required:
+                                      - key
+                                      - path
+                                      - volumeName
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                        default: false
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount containing the env file.
                                         type: string
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -4115,9 +4408,10 @@ spec:
                               operator:
                                 description: |-
                                   Operator represents a key's relationship to the value.
-                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                   Exists is equivalent to wildcard for value, so that a pod can
                                   tolerate all taints of a particular category.
+                                  Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                 type: string
                               tolerationSeconds:
                                 description: |-
@@ -4261,7 +4555,6 @@ spec:
                                   - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                                   If this value is nil, the behavior is equivalent to the Honor policy.
-                                  This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                 type: string
                               nodeTaintsPolicy:
                                 description: |-
@@ -4272,7 +4565,6 @@ spec:
                                   - Ignore: node taints are ignored. All nodes are included.
 
                                   If this value is nil, the behavior is equivalent to the Ignore policy.
-                                  This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                 type: string
                               topologyKey:
                                 description: |-
@@ -4738,6 +5030,128 @@ spec:
                                                 type: string
                                             x-kubernetes-map-type: atomic
                                       x-kubernetes-list-type: atomic
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  type: object
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      type: integer
+                                      format: int32
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                    userAnnotations:
+                                      description: |-
+                                        userAnnotations allow pod authors to pass additional information to
+                                        the signer implementation.  Kubernetes does not restrict or validate this
+                                        metadata in any way.
+
+                                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                        the PodCertificateRequest objects that Kubelet creates.
+
+                                        Entries are subject to the same validation as object metadata annotations,
+                                        with the addition that all keys must be domain-prefixed. No restrictions
+                                        are placed on values, except an overall size limitation on the entire field.
+
+                                        Signers should document the keys and values they support. Signers should
+                                        deny requests that contain keys they do not recognize.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
                                 secret:
                                   description: secret information about the secret data to project
                                   type: object
@@ -5049,6 +5463,14 @@ spec:
                           type: boolean
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
+                          type: boolean
+                        enableTektonOCIBundles:
+                          description: |-
+                            DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
+                            to allow deletion of PipelineRuns created before v0.62.x.
+                            This field is not used and can be removed in a future release
+                            once we're confident old PipelineRuns have been cleaned up.
+                            See issue #8359 for context.
                           type: boolean
                         enableWaitExponentialBackoff:
                           type: boolean

--- a/charts/tekton-pipeline/crds/pipelines.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/pipelines.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
-    version: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
+    version: "v1.12.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/resolutionrequests.resolution.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/resolutionrequests.resolution.tekton.dev-crd.yaml
@@ -28,9 +28,6 @@ spec:
     categories:
       - tekton
       - tekton-pipelines
-    shortNames:
-      - resolutionrequest
-      - resolutionrequests
   versions:
     - name: v1alpha1
       served: true

--- a/charts/tekton-pipeline/crds/stepactions.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/stepactions.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
-    version: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
+    version: "v1.12.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -101,7 +101,9 @@ spec:
                       - name
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -154,6 +156,42 @@ spec:
                                 type: string
                               fieldPath:
                                 description: Path of the field to select in the specified API version.
+                                type: string
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            type: object
+                            required:
+                              - key
+                              - path
+                              - volumeName
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                                default: false
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
                                 type: string
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
@@ -616,7 +654,9 @@ spec:
                       - name
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -669,6 +709,42 @@ spec:
                                 type: string
                               fieldPath:
                                 description: Path of the field to select in the specified API version.
+                                type: string
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            type: object
+                            required:
+                              - key
+                              - path
+                              - volumeName
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                                default: false
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
                                 type: string
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:

--- a/charts/tekton-pipeline/crds/taskruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/taskruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
-    version: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
+    version: "v1.12.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -65,7 +65,7 @@ spec:
                         Claims lists the names of resources, defined in spec.resourceClaims,
                         that are used by this container.
 
-                        This is an alpha field and requires enabling the
+                        This field depends on the
                         DynamicResourceAllocation feature gate.
 
                         This field is immutable. It can only be set for containers.
@@ -232,7 +232,9 @@ spec:
                           - name
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -285,6 +287,42 @@ spec:
                                     type: string
                                   fieldPath:
                                     description: Path of the field to select in the specified API version.
+                                    type: string
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                type: object
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                    default: false
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
                                     type: string
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -448,9 +486,10 @@ spec:
                           operator:
                             description: |-
                               Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                               Exists is equivalent to wildcard for value, so that a pod can
                               tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                             type: string
                           tolerationSeconds:
                             description: |-
@@ -594,7 +633,6 @@ spec:
                               - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                               If this value is nil, the behavior is equivalent to the Honor policy.
-                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                             type: string
                           nodeTaintsPolicy:
                             description: |-
@@ -605,7 +643,6 @@ spec:
                               - Ignore: node taints are ignored. All nodes are included.
 
                               If this value is nil, the behavior is equivalent to the Ignore policy.
-                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                             type: string
                           topologyKey:
                             description: |-
@@ -858,7 +895,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -937,7 +974,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -1428,6 +1465,128 @@ spec:
                                                 type: string
                                             x-kubernetes-map-type: atomic
                                       x-kubernetes-list-type: atomic
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  type: object
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      type: integer
+                                      format: int32
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                    userAnnotations:
+                                      description: |-
+                                        userAnnotations allow pod authors to pass additional information to
+                                        the signer implementation.  Kubernetes does not restrict or validate this
+                                        metadata in any way.
+
+                                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                        the PodCertificateRequest objects that Kubelet creates.
+
+                                        Entries are subject to the same validation as object metadata annotations,
+                                        with the addition that all keys must be domain-prefixed. No restrictions
+                                        are placed on values, except an overall size limitation on the entire field.
+
+                                        Signers should document the keys and values they support. Signers should
+                                        deny requests that contain keys they do not recognize.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
                                 secret:
                                   description: secret information about the secret data to project
                                   type: object
@@ -1596,9 +1755,7 @@ spec:
                   additionalProperties:
                     type: string
                 cloudEvents:
-                  description: |-
-                    Deprecated: Removed in v0.44.0.
-                    CloudEvents
+                  description: CloudEvents
                   type: array
                   items:
                     description: CloudEventDelivery
@@ -1728,6 +1885,14 @@ spec:
                           type: boolean
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
+                          type: boolean
+                        enableTektonOCIBundles:
+                          description: |-
+                            DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
+                            to allow deletion of PipelineRuns created before v0.62.x.
+                            This field is not used and can be removed in a future release
+                            once we're confident old PipelineRuns have been cleaned up.
+                            See issue #8359 for context.
                           type: boolean
                         enableWaitExponentialBackoff:
                           type: boolean
@@ -1992,6 +2157,14 @@ spec:
                               enableStepActions:
                                 description: EnableStepActions is a no-op flag since StepActions are stable
                                 type: boolean
+                              enableTektonOCIBundles:
+                                description: |-
+                                  DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
+                                  to allow deletion of PipelineRuns created before v0.62.x.
+                                  This field is not used and can be removed in a future release
+                                  once we're confident old PipelineRuns have been cleaned up.
+                                  See issue #8359 for context.
+                                type: boolean
                               enableWaitExponentialBackoff:
                                 type: boolean
                               enforceNonfalsifiability:
@@ -2182,7 +2355,7 @@ spec:
                         Claims lists the names of resources, defined in spec.resourceClaims,
                         that are used by this container.
 
-                        This is an alpha field and requires enabling the
+                        This field depends on the
                         DynamicResourceAllocation feature gate.
 
                         This field is immutable. It can only be set for containers.
@@ -2353,7 +2526,9 @@ spec:
                           - name
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -2406,6 +2581,42 @@ spec:
                                     type: string
                                   fieldPath:
                                     description: Path of the field to select in the specified API version.
+                                    type: string
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                type: object
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                    default: false
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
                                     type: string
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -2569,9 +2780,10 @@ spec:
                           operator:
                             description: |-
                               Operator represents a key's relationship to the value.
-                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                               Exists is equivalent to wildcard for value, so that a pod can
                               tolerate all taints of a particular category.
+                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                             type: string
                           tolerationSeconds:
                             description: |-
@@ -2715,7 +2927,6 @@ spec:
                               - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                               If this value is nil, the behavior is equivalent to the Honor policy.
-                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                             type: string
                           nodeTaintsPolicy:
                             description: |-
@@ -2726,7 +2937,6 @@ spec:
                               - Ignore: node taints are ignored. All nodes are included.
 
                               If this value is nil, the behavior is equivalent to the Ignore policy.
-                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                             type: string
                           topologyKey:
                             description: |-
@@ -2797,7 +3007,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -2880,7 +3090,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -3389,6 +3599,128 @@ spec:
                                                 type: string
                                             x-kubernetes-map-type: atomic
                                       x-kubernetes-list-type: atomic
+                                podCertificate:
+                                  description: |-
+                                    Projects an auto-rotating credential bundle (private key and certificate
+                                    chain) that the pod can use either as a TLS client or server.
+
+                                    Kubelet generates a private key and uses it to send a
+                                    PodCertificateRequest to the named signer.  Once the signer approves the
+                                    request and issues a certificate chain, Kubelet writes the key and
+                                    certificate chain to the pod filesystem.  The pod does not start until
+                                    certificates have been issued for each podCertificate projected volume
+                                    source in its spec.
+
+                                    Kubelet will begin trying to rotate the certificate at the time indicated
+                                    by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                    timestamp.
+
+                                    Kubelet can write a single file, indicated by the credentialBundlePath
+                                    field, or separate files, indicated by the keyPath and
+                                    certificateChainPath fields.
+
+                                    The credential bundle is a single file in PEM format.  The first PEM
+                                    entry is the private key (in PKCS#8 format), and the remaining PEM
+                                    entries are the certificate chain issued by the signer (typically,
+                                    signers will return their certificate chain in leaf-to-root order).
+
+                                    Prefer using the credential bundle format, since your application code
+                                    can read it atomically.  If you use keyPath and certificateChainPath,
+                                    your application must make two separate file reads. If these coincide
+                                    with a certificate rotation, it is possible that the private key and leaf
+                                    certificate you read may not correspond to each other.  Your application
+                                    will need to check for this condition, and re-read until they are
+                                    consistent.
+
+                                    The named signer controls chooses the format of the certificate it
+                                    issues; consult the signer implementation's documentation to learn how to
+                                    use the certificates it issues.
+                                  type: object
+                                  required:
+                                    - keyType
+                                    - signerName
+                                  properties:
+                                    certificateChainPath:
+                                      description: |-
+                                        Write the certificate chain at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    credentialBundlePath:
+                                      description: |-
+                                        Write the credential bundle at this path in the projected volume.
+
+                                        The credential bundle is a single file that contains multiple PEM blocks.
+                                        The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                        key.
+
+                                        The remaining blocks are CERTIFICATE blocks, containing the issued
+                                        certificate chain from the signer (leaf and any intermediates).
+
+                                        Using credentialBundlePath lets your Pod's application code make a single
+                                        atomic read that retrieves a consistent key and certificate chain.  If you
+                                        project them to separate files, your application code will need to
+                                        additionally check that the leaf certificate was issued to the key.
+                                      type: string
+                                    keyPath:
+                                      description: |-
+                                        Write the key at this path in the projected volume.
+
+                                        Most applications should use credentialBundlePath.  When using keyPath
+                                        and certificateChainPath, your application needs to check that the key
+                                        and leaf certificate are consistent, because it is possible to read the
+                                        files mid-rotation.
+                                      type: string
+                                    keyType:
+                                      description: |-
+                                        The type of keypair Kubelet will generate for the pod.
+
+                                        Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                        "ECDSAP521", and "ED25519".
+                                      type: string
+                                    maxExpirationSeconds:
+                                      description: |-
+                                        maxExpirationSeconds is the maximum lifetime permitted for the
+                                        certificate.
+
+                                        Kubelet copies this value verbatim into the PodCertificateRequests it
+                                        generates for this projection.
+
+                                        If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                        will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                        value is 7862400 (91 days).
+
+                                        The signer implementation is then free to issue a certificate with any
+                                        lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                        seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                        `kubernetes.io` signers will never issue certificates with a lifetime
+                                        longer than 24 hours.
+                                      type: integer
+                                      format: int32
+                                    signerName:
+                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                      type: string
+                                    userAnnotations:
+                                      description: |-
+                                        userAnnotations allow pod authors to pass additional information to
+                                        the signer implementation.  Kubernetes does not restrict or validate this
+                                        metadata in any way.
+
+                                        These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                        the PodCertificateRequest objects that Kubelet creates.
+
+                                        Entries are subject to the same validation as object metadata annotations,
+                                        with the addition that all keys must be domain-prefixed. No restrictions
+                                        are placed on values, except an overall size limitation on the entire field.
+
+                                        Signers should document the keys and values they support. Signers should
+                                        deny requests that contain keys they do not recognize.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
                                 secret:
                                   description: secret information about the secret data to project
                                   type: object
@@ -3704,6 +4036,14 @@ spec:
                         enableStepActions:
                           description: EnableStepActions is a no-op flag since StepActions are stable
                           type: boolean
+                        enableTektonOCIBundles:
+                          description: |-
+                            DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
+                            to allow deletion of PipelineRuns created before v0.62.x.
+                            This field is not used and can be removed in a future release
+                            once we're confident old PipelineRuns have been cleaned up.
+                            See issue #8359 for context.
+                          type: boolean
                         enableWaitExponentialBackoff:
                           type: boolean
                         enforceNonfalsifiability:
@@ -3958,6 +4298,14 @@ spec:
                                 type: boolean
                               enableStepActions:
                                 description: EnableStepActions is a no-op flag since StepActions are stable
+                                type: boolean
+                              enableTektonOCIBundles:
+                                description: |-
+                                  DeprecatedEnableTektonOCIBundles is maintained for backward compatibility
+                                  to allow deletion of PipelineRuns created before v0.62.x.
+                                  This field is not used and can be removed in a future release
+                                  once we're confident old PipelineRuns have been cleaned up.
+                                  See issue #8359 for context.
                                 type: boolean
                               enableWaitExponentialBackoff:
                                 type: boolean
@@ -4234,7 +4582,7 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-                                  This is an alpha field and requires enabling the
+                                  This field depends on the
                                   DynamicResourceAllocation feature gate.
 
                                   This field is immutable. It can only be set for containers.
@@ -4296,7 +4644,9 @@ spec:
                                 - name
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 value:
                                   description: |-
@@ -4349,6 +4699,42 @@ spec:
                                           type: string
                                         fieldPath:
                                           description: Path of the field to select in the specified API version.
+                                          type: string
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                          default: false
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount containing the env file.
                                           type: string
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
@@ -4406,7 +4792,7 @@ spec:
                               Cannot be updated.
                             type: array
                             items:
-                              description: EnvFromSource represents the source of a set of ConfigMaps
+                              description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                               type: object
                               properties:
                                 configMapRef:
@@ -4427,7 +4813,9 @@ spec:
                                       type: boolean
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: |-
+                                    Optional text to prepend to the name of each environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from
@@ -4673,6 +5061,12 @@ spec:
                                           - type: integer
                                           - type: string
                                         x-kubernetes-int-or-string: true
+                              stopSignal:
+                                description: |-
+                                  StopSignal defines which signal will be sent to a container when it is being stopped.
+                                  If not specified, the default is defined by the container runtime in use.
+                                  StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                type: string
                           livenessProbe:
                             description: |-
                               Periodic probe of Sidecar liveness.
@@ -5591,7 +5985,7 @@ spec:
                                 Claims lists the names of resources, defined in spec.resourceClaims,
                                 that are used by this container.
 
-                                This is an alpha field and requires enabling the
+                                This field depends on the
                                 DynamicResourceAllocation feature gate.
 
                                 This field is immutable. It can only be set for containers.
@@ -5653,7 +6047,9 @@ spec:
                               - name
                             properties:
                               name:
-                                description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -5706,6 +6102,42 @@ spec:
                                         type: string
                                       fieldPath:
                                         description: Path of the field to select in the specified API version.
+                                        type: string
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    type: object
+                                    required:
+                                      - key
+                                      - path
+                                      - volumeName
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                        default: false
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount containing the env file.
                                         type: string
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:
@@ -5763,7 +6195,7 @@ spec:
                             Cannot be updated.
                           type: array
                           items:
-                            description: EnvFromSource represents the source of a set of ConfigMaps
+                            description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                             type: object
                             properties:
                               configMapRef:
@@ -5784,7 +6216,9 @@ spec:
                                     type: boolean
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Optional text to prepend to the name of each environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -6146,7 +6580,7 @@ spec:
                                   Claims lists the names of resources, defined in spec.resourceClaims,
                                   that are used by this container.
 
-                                  This is an alpha field and requires enabling the
+                                  This field depends on the
                                   DynamicResourceAllocation feature gate.
 
                                   This field is immutable. It can only be set for containers.
@@ -6213,7 +6647,9 @@ spec:
                                 - name
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                  description: |-
+                                    Name of the environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 value:
                                   description: |-
@@ -6266,6 +6702,42 @@ spec:
                                           type: string
                                         fieldPath:
                                           description: Path of the field to select in the specified API version.
+                                          type: string
+                                      x-kubernetes-map-type: atomic
+                                    fileKeyRef:
+                                      description: |-
+                                        FileKeyRef selects a key of the env file.
+                                        Requires the EnvFiles feature gate to be enabled.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                      properties:
+                                        key:
+                                          description: |-
+                                            The key within the env file. An invalid key will prevent the pod from starting.
+                                            The keys defined within a source may consist of any printable ASCII characters except '='.
+                                            During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                          type: string
+                                        optional:
+                                          description: |-
+                                            Specify whether the file or its key must be defined. If the file or key
+                                            does not exist, then the env var is not published.
+                                            If optional is set to true and the specified key does not exist,
+                                            the environment variable will not be set in the Pod's containers.
+
+                                            If optional is set to false and the specified key does not exist,
+                                            an error will be returned during Pod creation.
+                                          type: boolean
+                                          default: false
+                                        path:
+                                          description: |-
+                                            The path within the volume from which to select the file.
+                                            Must be relative and may not contain the '..' path or start with '..'.
+                                          type: string
+                                        volumeName:
+                                          description: The name of the volume mount containing the env file.
                                           type: string
                                       x-kubernetes-map-type: atomic
                                     resourceFieldRef:
@@ -6323,7 +6795,7 @@ spec:
                               Cannot be updated.
                             type: array
                             items:
-                              description: EnvFromSource represents the source of a set of ConfigMaps
+                              description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                               type: object
                               properties:
                                 configMapRef:
@@ -6344,7 +6816,9 @@ spec:
                                       type: boolean
                                   x-kubernetes-map-type: atomic
                                 prefix:
-                                  description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  description: |-
+                                    Optional text to prepend to the name of each environment variable.
+                                    May consist of any printable ASCII characters except '='.
                                   type: string
                                 secretRef:
                                   description: The Secret to select from

--- a/charts/tekton-pipeline/crds/tasks.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/tasks.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
-    version: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
+    version: "v1.12.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -246,7 +246,9 @@ spec:
                             - name
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -301,6 +303,42 @@ spec:
                                       description: Path of the field to select in the specified API version.
                                       type: string
                                   x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  type: object
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                      default: false
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing the env file.
+                                      type: string
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: |-
                                     Selects a resource of the container: only resources limits and requests
@@ -350,7 +388,7 @@ spec:
                         description: EnvFrom
                         type: array
                         items:
-                          description: EnvFromSource represents the source of a set of ConfigMaps
+                          description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                           type: object
                           properties:
                             configMapRef:
@@ -371,7 +409,9 @@ spec:
                                   type: boolean
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: |-
+                                Optional text to prepend to the name of each environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -608,6 +648,12 @@ spec:
                                       - type: integer
                                       - type: string
                                     x-kubernetes-int-or-string: true
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
                       livenessProbe:
                         description: LivenessProbe
                         type: object
@@ -956,7 +1002,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -1489,7 +1535,9 @@ spec:
                           - name
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -1544,6 +1592,42 @@ spec:
                                     description: Path of the field to select in the specified API version.
                                     type: string
                                 x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                type: object
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                    default: false
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
+                                    type: string
+                                x-kubernetes-map-type: atomic
                               resourceFieldRef:
                                 description: |-
                                   Selects a resource of the container: only resources limits and requests
@@ -1593,7 +1677,7 @@ spec:
                       description: EnvFrom
                       type: array
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                         type: object
                         properties:
                           configMapRef:
@@ -1614,7 +1698,9 @@ spec:
                                 type: boolean
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -1853,6 +1939,12 @@ spec:
                                     - type: integer
                                     - type: string
                                   x-kubernetes-int-or-string: true
+                        stopSignal:
+                          description: |-
+                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                            If not specified, the default is defined by the container runtime in use.
+                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                          type: string
                     livenessProbe:
                       description: |-
                         Deprecated: This field will be removed in a future release.
@@ -2209,7 +2301,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This is an alpha field and requires enabling the
+                            This field depends on the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -2736,7 +2828,9 @@ spec:
                             - name
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -2791,6 +2885,42 @@ spec:
                                       description: Path of the field to select in the specified API version.
                                       type: string
                                   x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  type: object
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                      default: false
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing the env file.
+                                      type: string
+                                  x-kubernetes-map-type: atomic
                                 resourceFieldRef:
                                   description: |-
                                     Selects a resource of the container: only resources limits and requests
@@ -2840,7 +2970,7 @@ spec:
                         description: EnvFrom
                         type: array
                         items:
-                          description: EnvFromSource represents the source of a set of ConfigMaps
+                          description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                           type: object
                           properties:
                             configMapRef:
@@ -2861,7 +2991,9 @@ spec:
                                   type: boolean
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: |-
+                                Optional text to prepend to the name of each environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -3100,6 +3232,12 @@ spec:
                                       - type: integer
                                       - type: string
                                     x-kubernetes-int-or-string: true
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
                       livenessProbe:
                         description: |-
                           Deprecated: This field will be removed in a future release.
@@ -3499,7 +3637,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -4299,7 +4437,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -4361,7 +4499,9 @@ spec:
                             - name
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -4414,6 +4554,42 @@ spec:
                                       type: string
                                     fieldPath:
                                       description: Path of the field to select in the specified API version.
+                                      type: string
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  type: object
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                      default: false
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing the env file.
                                       type: string
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -4471,7 +4647,7 @@ spec:
                           Cannot be updated.
                         type: array
                         items:
-                          description: EnvFromSource represents the source of a set of ConfigMaps
+                          description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                           type: object
                           properties:
                             configMapRef:
@@ -4492,7 +4668,9 @@ spec:
                                   type: boolean
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: |-
+                                Optional text to prepend to the name of each environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -4738,6 +4916,12 @@ spec:
                                       - type: integer
                                       - type: string
                                     x-kubernetes-int-or-string: true
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
                       livenessProbe:
                         description: |-
                           Periodic probe of Sidecar liveness.
@@ -5656,7 +5840,7 @@ spec:
                             Claims lists the names of resources, defined in spec.resourceClaims,
                             that are used by this container.
 
-                            This is an alpha field and requires enabling the
+                            This field depends on the
                             DynamicResourceAllocation feature gate.
 
                             This field is immutable. It can only be set for containers.
@@ -5718,7 +5902,9 @@ spec:
                           - name
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a C_IDENTIFIER.
+                            description: |-
+                              Name of the environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           value:
                             description: |-
@@ -5771,6 +5957,42 @@ spec:
                                     type: string
                                   fieldPath:
                                     description: Path of the field to select in the specified API version.
+                                    type: string
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                description: |-
+                                  FileKeyRef selects a key of the env file.
+                                  Requires the EnvFiles feature gate to be enabled.
+                                type: object
+                                required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                properties:
+                                  key:
+                                    description: |-
+                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                    type: string
+                                  optional:
+                                    description: |-
+                                      Specify whether the file or its key must be defined. If the file or key
+                                      does not exist, then the env var is not published.
+                                      If optional is set to true and the specified key does not exist,
+                                      the environment variable will not be set in the Pod's containers.
+
+                                      If optional is set to false and the specified key does not exist,
+                                      an error will be returned during Pod creation.
+                                    type: boolean
+                                    default: false
+                                  path:
+                                    description: |-
+                                      The path within the volume from which to select the file.
+                                      Must be relative and may not contain the '..' path or start with '..'.
+                                    type: string
+                                  volumeName:
+                                    description: The name of the volume mount containing the env file.
                                     type: string
                                 x-kubernetes-map-type: atomic
                               resourceFieldRef:
@@ -5828,7 +6050,7 @@ spec:
                         Cannot be updated.
                       type: array
                       items:
-                        description: EnvFromSource represents the source of a set of ConfigMaps
+                        description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                         type: object
                         properties:
                           configMapRef:
@@ -5849,7 +6071,9 @@ spec:
                                 type: boolean
                             x-kubernetes-map-type: atomic
                           prefix:
-                            description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                            description: |-
+                              Optional text to prepend to the name of each environment variable.
+                              May consist of any printable ASCII characters except '='.
                             type: string
                           secretRef:
                             description: The Secret to select from
@@ -6211,7 +6435,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -6278,7 +6502,9 @@ spec:
                             - name
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -6331,6 +6557,42 @@ spec:
                                       type: string
                                     fieldPath:
                                       description: Path of the field to select in the specified API version.
+                                      type: string
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  type: object
+                                  required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                      default: false
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing the env file.
                                       type: string
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
@@ -6388,7 +6650,7 @@ spec:
                           Cannot be updated.
                         type: array
                         items:
-                          description: EnvFromSource represents the source of a set of ConfigMaps
+                          description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                           type: object
                           properties:
                             configMapRef:
@@ -6409,7 +6671,9 @@ spec:
                                   type: boolean
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: |-
+                                Optional text to prepend to the name of each environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             secretRef:
                               description: The Secret to select from

--- a/charts/tekton-pipeline/crds/verificationpolicies.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/verificationpolicies.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
-    version: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
+    version: "v1.12.0"
 spec:
   group: tekton.dev
   versions:

--- a/charts/tekton-pipeline/templates/config-events-cm.yaml
+++ b/charts/tekton-pipeline/templates/config-events-cm.yaml
@@ -36,7 +36,7 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
-    # formats contains a comma seperated list of event formats to be used
+    # formats contains a comma separated list of event formats to be used
     # the only format supported today is "tektonv1". An empty string is not
     # a valid configuration. To disable events, do not specify the sink.
     formats: "tektonv1"

--- a/charts/tekton-pipeline/templates/config-observability-cm.yaml
+++ b/charts/tekton-pipeline/templates/config-observability-cm.yaml
@@ -21,6 +21,7 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 data:
+  metrics-protocol: prometheus
   _example: |
     ################################
     #                              #
@@ -37,24 +38,41 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
 
-    # metrics.backend-destination field specifies the system metrics destination.
-    # It supports either prometheus (the default) or stackdriver.
-    # Note: Using stackdriver will incur additional charges
-    metrics.backend-destination: prometheus
+    # OpenTelemetry Metrics Configuration
+    # Protocol for metrics export (prometheus, grpc, http/protobuf, none)
+    # Default if not specified: "none"
+    metrics-protocol: prometheus
 
-    # metrics.request-metrics-backend-destination specifies the request metrics
-    # destination. If non-empty, it enables queue proxy to send request metrics.
-    # Currently supported values: prometheus, stackdriver.
-    metrics.request-metrics-backend-destination: prometheus
+    # Metrics endpoint (for grpc/http protocols)
+    # Default: empty (uses default OTLP endpoint)
+    metrics-endpoint: ""
 
-    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
-    # field is optional. When running on GCE, application default credentials will be
-    # used if this field is not provided.
-    metrics.stackdriver-project-id: "<your stackdriver project id>"
+    # Metrics export interval (e.g., "30s", "1m")
+    # Default: empty (uses default interval)
+    metrics-export-interval: ""
 
-    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
-    # Stackdriver using "global" resource type and custom metric type if the
-    # metrics are not supported by "knative_revision" resource type. Setting this
-    # flag to "true" could cause extra Stackdriver charge.
-    # If metrics.backend-destination is not Stackdriver, this is ignored.
-    metrics.allow-stackdriver-custom-metrics: "false"
+    # OpenTelemetry Tracing Configuration
+    # Protocol for tracing export (grpc, http/protobuf, none, stdout)
+    # Default: none
+    tracing-protocol: none
+
+    # Tracing endpoint (for grpc/http protocols)
+    # Default: empty
+    tracing-endpoint: ""
+
+    # Tracing sampling rate (0.0 to 1.0)
+    # Default: 1.0 (100% sampling)
+    tracing-sampling-rate: "1.0"
+
+    # Runtime Configuration
+    # Enable profiling (enabled, disabled)
+    # Default: disabled
+    runtime-profiling: disabled
+
+    # Runtime export interval (e.g., "15s")
+    # Default: 15s
+    runtime-export-interval: "15s"
+
+    # Note: Legacy OpenCensus configuration (metrics.backend-destination, etc.) has been
+    # removed as OpenCensus support is no longer provided by the underlying infrastructure.
+    # Please use the OpenTelemetry configuration options above.

--- a/charts/tekton-pipeline/templates/config-tracing-cm.yaml
+++ b/charts/tekton-pipeline/templates/config-tracing-cm.yaml
@@ -40,6 +40,6 @@ data:
     #
     # API endpoint to send the traces to
     # (optional): The default value is given below
-    endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:14268/api/traces"
+    endpoint: "http://jaeger-collector.jaeger.svc.cluster.local:4318/v1/traces"
     # (optional) Name of the k8s secret which contains basic auth credentials
     credentialsSecret: "jaeger-creds"

--- a/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/hubresolver-config-cm.yaml
+++ b/charts/tekton-pipeline/templates/hubresolver-config-cm.yaml
@@ -31,3 +31,14 @@ data:
   default-kind: "task"
   # the default hub source to pull the resource from.
   default-type: "artifact"
+  # Ordered list of Artifact Hub API URLs to try. First successful response wins.
+  # If not set, the ARTIFACT_HUB_API env var or default (https://artifacthub.io) is used.
+  # URLs must use http or https scheme.
+  # artifact-hub-urls: |
+  #   - https://internal-hub.example.com/
+  #   - https://artifacthub.io/
+  # Ordered list of Tekton Hub API URLs to try. First successful response wins.
+  # If not set, the TEKTON_HUB_API env var is used.
+  # URLs must use http or https scheme.
+  # tekton-hub-urls: |
+  #   - https://api.hub.tekton.dev/

--- a/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
+++ b/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
@@ -25,4 +25,4 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace we still can have access to
   # this ConfigMap.
-  version: "v1.9.2"
+  version: "v1.12.0"

--- a/charts/tekton-pipeline/templates/tekton-events-controller-cluster-access-clusterrole.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-cluster-access-clusterrole.yaml
@@ -11,4 +11,7 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["tasks", "taskruns", "pipelines", "pipelineruns", "customruns"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
 {{- end }}

--- a/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
@@ -6,9 +6,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: events
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.9.2
-    pipeline.tekton.dev/release: v1.9.2
-    version: v1.9.2
+    app.kubernetes.io/version: v1.12.0
+    pipeline.tekton.dev/release: v1.12.0
+    version: v1.12.0
   name: tekton-events-controller
 spec:
   replicas: 1
@@ -26,9 +26,9 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: events
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.9.2
-        pipeline.tekton.dev/release: v1.9.2
-        version: v1.9.2
+        app.kubernetes.io/version: v1.12.0
+        pipeline.tekton.dev/release: v1.12.0
+        version: v1.12.0
     spec:
       affinity:
         nodeAffinity:

--- a/charts/tekton-pipeline/templates/tekton-events-controller-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: events
     app.kubernetes.io/component: events
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.12.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-events-controller
-    version: "v1.9.2"
+    version: "v1.12.0"
   name: tekton-events-controller
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.9.2
+    app.kubernetes.io/version: v1.12.0
       {{- with .Values.controller.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v1.9.2
-    version: v1.9.2
+    pipeline.tekton.dev/release: v1.12.0
+    version: v1.12.0
   name: tekton-pipelines-controller
 spec:
   replicas: 1
@@ -34,12 +34,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: controller
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.9.2
+        app.kubernetes.io/version: v1.12.0
           {{- with .Values.controller.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v1.9.2
-        version: v1.9.2
+        pipeline.tekton.dev/release: v1.12.0
+        version: v1.12.0
     spec:
       affinity:
           {{- with .Values.controller.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.12.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-controller
-    version: "v1.9.2"
+    version: "v1.12.0"
   name: tekton-pipelines-controller
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -6,9 +6,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.9.2
-    pipeline.tekton.dev/release: v1.9.2
-    version: v1.9.2
+    app.kubernetes.io/version: v1.12.0
+    pipeline.tekton.dev/release: v1.12.0
+    version: v1.12.0
   name: tekton-pipelines-remote-resolvers
 spec:
   replicas: 1
@@ -26,9 +26,9 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: resolvers
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.9.2
-        pipeline.tekton.dev/release: v1.9.2
-        version: v1.9.2
+        app.kubernetes.io/version: v1.12.0
+        pipeline.tekton.dev/release: v1.12.0
+        version: v1.12.0
     spec:
       affinity:
           {{- with .Values.remoteresolver.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-svc.yaml
@@ -18,13 +18,13 @@ metadata:
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/component: resolvers
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.12.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-remote-resolvers
-    version: "v1.9.2"
+    version: "v1.12.0"
   name: tekton-pipelines-remote-resolvers
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.9.2
+    app.kubernetes.io/version: v1.12.0
       {{- with .Values.webhook.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v1.9.2
-    version: v1.9.2
+    pipeline.tekton.dev/release: v1.12.0
+    version: v1.12.0
   name: tekton-pipelines-webhook
 spec:
   selector:
@@ -28,12 +28,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: webhook
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.9.2
+        app.kubernetes.io/version: v1.12.0
           {{- with .Values.webhook.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v1.9.2
-        version: v1.9.2
+        pipeline.tekton.dev/release: v1.12.0
+        version: v1.12.0
     spec:
       affinity:
           {{- with .Values.webhook.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
@@ -20,12 +20,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.12.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v1.9.2"
+    version: "v1.12.0"
 spec:
   minReplicas: 1
   maxReplicas: 5

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.9.2"
+    app.kubernetes.io/version: "v1.12.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-webhook
-    version: "v1.9.2"
+    version: "v1.12.0"
   name: tekton-pipelines-webhook
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
+++ b/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
@@ -20,5 +20,5 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
     # The data is populated at install time.

--- a/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.9.2"
+    pipeline.tekton.dev/release: "v1.12.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -25,13 +25,13 @@ serviceaccount:
 # Values for tekton-pipelines-controller
 controller:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.9.2@sha256:a6833aa4bd352d33335d4a9329fce13e44407773c703d71099aa07d0f2846826
+    image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.12.0@sha256:8d5f900677386b8fe5371429e9c1461b25de47e5e34736c7f99e82e2c279ebbc
     labels: {}
   images:
-    entrypoint: "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.9.2@sha256:f9b98c1f7fc4a747dc0d118def8bbde58c81da31c5d80e2d70f7f67b2cf16982"
-    nop: "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.9.2@sha256:5a125c13f79fe80d09eca799293efa775ba37aed1322a18a49f11052401dac21"
-    sidecarlogresults: "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.9.2@sha256:0623a2085539a1aac38c2b89da59cc544839c7085684861e24737068a80acaa0"
-    workingdirinit: "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.9.2@sha256:57f4e62abb27e460ec1cef38c911ab9b53ca5f3757b88828e8d2c24e5718112e"
+    entrypoint: "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.12.0@sha256:3ec960b07abd85604242e146092e72f11be8787452c2a20d12a37fdee4a666e2"
+    nop: "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.12.0@sha256:f89fb760b05fdef6895290e524d992b66ede72546622d5028b0406a9bea36d2f"
+    sidecarlogresults: "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.12.0@sha256:8b61bdcad62a99e7b15f9dc92690ea39f49be2c5a1c9f428a0aac712f349543d"
+    workingdirinit: "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.12.0@sha256:11031cbed2b8ddbb5af0947a5e0c997ba7cd3da5f309ddfa76e58f5418868d71"
     shellImage: "cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791"
     shellImageWin: "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6"
   pod:
@@ -55,7 +55,7 @@ controller:
 # Values for tekton-pipelines-webhook
 webhook:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.9.2@sha256:60189c3482571001d2be2f3cb5b9ca41a10b885fe12e743847ebe0f5ccfb788a
+    image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.12.0@sha256:1e4eded1773f6fa8ec67c9348f84bed0d39666a9698ebd1ffb4eaed88b38f7d4
     labels: {}
   pod:
     labels: {}
@@ -76,7 +76,7 @@ webhook:
 # Values to amend tekton-pipelines-remote-resolvers
 remoteresolver:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.9.2@sha256:e83af2b69c5546ad6bfca67c2903ce92ef6012c1b3bcab54b5c7b38121228a58
+    image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.12.0@sha256:b1f06197342ed946b23efd1ce124d7c17d50678b461733a6cc0912b07a4943e7
   affinity: {}
   tolerations: []
   nodeSelector: {}
@@ -90,7 +90,7 @@ remoteresolver:
 # Values for tekton-events-controller
 eventscontroller:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.9.2@sha256:3cfd35631998087b2eafb40705fe9e0fae115e5f3c4aaec56c942e179fd6c14e
+    image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.12.0@sha256:d5d5869215a58fea01ce627d605786090949a324969102ab1fd25716adde10e9
 # configuration to put in the config-defaults ConfigMap
 configDefaults:
   _example: |
@@ -214,7 +214,7 @@ configDefaults:
     #       memory: "128Mi"
     #       cpu: "500m"
     #
-    #   default: # updates resource requirements of init-containers and containers which has empty resource resource requirements
+    #   default: # updates resource requirements of init-containers and containers which has empty resource requirements
     #     requests:
     #       memory: "64Mi"
     #       cpu: "250m"
@@ -319,9 +319,11 @@ featureFlags:
   # Setting this flag will determine which gated features are enabled.
   # Acceptable values are "stable", "beta", or "alpha".
   enable-api-fields: "beta"
-  # Setting this flag to "true" enables CloudEvents for CustomRuns and Runs, as long as a
-  # CloudEvents sink is configured in the config-defaults config map
-  send-cloudevents-for-runs: "false"
+  # DEPRECATED: send-cloudevents-for-runs is deprecated and will be removed in a future
+  # release. CloudEvents are now enabled by default when a sink is configured in the
+  # config-events ConfigMap. This flag only affects CustomRuns; it has no effect on
+  # TaskRuns or PipelineRuns.
+  send-cloudevents-for-runs: "true"
   # This flag affects the behavior of taskruns and pipelineruns in cases where no VerificationPolicies match them.
   # If it is set to "fail", TaskRuns and PipelineRuns will fail verification if no matching policies are found.
   # If it is set to "warn", TaskRuns and PipelineRuns will run to completion if no matching policies are found, and an error will be logged.


### PR DESCRIPTION
## Summary

Upgrades Tekton Pipeline manifests from v1.9.2 to v1.12.0 (LTS).

## Changes

> Aggregated changelog — Tekton Pipeline **v1.9.3 → v1.12.0** (from chart v1.9.2).

---

### ⚠️ Breaking Changes

- **Metrics: OpenCensus → OpenTelemetry** _(v1.10.0)_: metrics renamed (`workqueue_*`, `go_*`), `reconcile_count`/`reconcile_latency` removed, new `reason` label on duration metrics, `config-observability` ConfigMap syntax updated. Pod latency metric changed from Gauge → Histogram (`pod` label removed).
- **CloudEvents: new dedicated controller** _(v1.12.0 — TEP-0137)_: CloudEvents are now emitted by a separate `tekton-events-controller` Deployment (previously handled inline by the pipeline controllers). Feature flag `send-cloudevents-for-runs` **deprecated**, default changed `false` → `true`.

---

### 🔒 Security Fixes

| CVE | Severity | Summary |
|---|---|---|
| GHSA-j5q5-j9gm-2w5c | 🔴 Critical | Git resolver path traversal via `pathInRepo` → arbitrary file read _(v1.10.2)_ |
| CVE-2026-40161 | 🔴 High | Git resolver leaks system API token to user-controlled `serverURL` _(v1.9.3)_ |
| CVE-2026-40938 | 🔴 High | Git resolver `revision` argument injection → RCE on resolver pod _(v1.9.3)_ |
| CVE-2026-33022 | 🟠 Medium | Controller DoS via resolver name > 31 chars _(v1.10.2)_ |
| CVE-2026-40923 | 🟡 Medium | VolumeMount `/tekton/` restriction bypass via non-normalized paths _(v1.9.3)_ |
| CVE-2026-25542 | 🟡 Medium | VerificationPolicy regex bypass via unanchored patterns _(v1.9.3)_ |
| CVE-2026-40924 | 🟡 Medium | HTTP resolver OOM DoS via unbounded response body (capped at 1 MiB) _(v1.9.3)_ |
| CVE-2025-6172x | 🟡 Medium | Go runtime bumped to 1.24.13 _(v1.9.3)_ |

---

### ✨ Features

- **TaskRun Pending status** _(v1.11.0)_: `spec.status: TaskRunPending` defers execution without creating a Pod (parity with PipelineRun)
- **PVC auto-cleanup** _(v1.11.0)_: annotation `tekton.dev/auto-cleanup-pvc: "true"` deletes `volumeClaimTemplate` PVCs on PipelineRun completion
- **Hub Resolver multi-URL** _(v1.11.0)_: multiple hub instances with ordered fallback
- **SHA-256 revision validation** in Git resolver _(v1.10.0)_
- **Granular TaskRun failure reasons** _(v1.12.0)_: `PodEvicted`, `InitContainerOOM`, `StepOOM`, `SidecarOOM`, etc. (replaces generic `Failed`)
- **Queued CloudEvents** _(v1.12.0)_: `pipelinerun.queued.v1` and `taskrun.queued.v1` emitted at creation time

---

### 🐛 Bug Fixes

- Git multi-credentials: HTTP (`useHttpPath`) and SSH (Host aliases) for multiple repos on the same host _(v1.11.0)_
- `step-init` symlink creation made idempotent — fixes container restart crash _(v1.11.0)_
- `spec.timeouts.tasks/finally` now propagated from PipelineRun to child TaskRuns _(v1.11.0)_
- Credential volume name collision fixed with deterministic SHA-256 hash _(v1.11.0)_
- Pipeline-level results collected even for failed/cancelled/timed-out tasks _(v1.10.0)_
- Resolver cache: race condition fixed via `singleflight`, corrupted entries cleaned up _(v1.9.3, v1.11.0)_
- `running_taskruns` and cancelled PipelineRun metrics fixed _(v1.9.3, v1.11.0)_
- `ResolutionRequest` CRD `shortNames` conflict on Kubernetes 1.33+ fixed _(v1.10.0)_

---

### ⚡ Performance & Deprecations

- Reduced reconciliation churn for completed PipelineRuns; `maps.Equal` replaces `reflect.DeepEqual` _(v1.12.0)_
- `send-cloudevents-for-runs` flag deprecated — will be removed in a future release _(v1.12.0)_

## Related
- [v1.9.3](https://github.com/tektoncd/pipeline/releases/tag/v1.9.3)
- [v1.10.0](https://github.com/tektoncd/pipeline/releases/tag/v1.10.0)
- [v1.10.1](https://github.com/tektoncd/pipeline/releases/tag/v1.10.1)
- [v1.10.2](https://github.com/tektoncd/pipeline/releases/tag/v1.10.2)
- [v1.11.0](https://github.com/tektoncd/pipeline/releases/tag/v1.11.0)
- [v1.11.1](https://github.com/tektoncd/pipeline/releases/tag/v1.11.1)
- [v1.12.0](https://github.com/tektoncd/pipeline/releases/tag/v1.12.0)