### PR TITLE
feat: support bring-your-own ServiceAccounts

### DIFF
--- a/charts/tekton-pipeline/templates/_helpers.tpl
+++ b/charts/tekton-pipeline/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/*
+ServiceAccount name resolvers.
+
+When .Values.serviceaccount.enabled is true, the chart creates the
+ServiceAccounts and all workloads/RBAC use the chart-generated names below.
+
+When it is false, the chart does NOT create the ServiceAccounts and the names
+provided in .Values.serviceaccount.names.<component> are used instead. If an
+override is left empty, the chart-generated name is used as a fallback to avoid
+rendering an empty serviceAccountName.
+*/}}
+
+{{- define "tektonPipeline.controller.serviceAccountName" -}}
+{{- if .Values.serviceaccount.enabled -}}
+tekton-pipelines-controller
+{{- else -}}
+{{- default "tekton-pipelines-controller" .Values.serviceaccount.names.controller -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tektonPipeline.webhook.serviceAccountName" -}}
+{{- if .Values.serviceaccount.enabled -}}
+tekton-pipelines-webhook
+{{- else -}}
+{{- default "tekton-pipelines-webhook" .Values.serviceaccount.names.webhook -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tektonPipeline.eventsController.serviceAccountName" -}}
+{{- if .Values.serviceaccount.enabled -}}
+tekton-events-controller
+{{- else -}}
+{{- default "tekton-events-controller" .Values.serviceaccount.names.eventsController -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tektonPipeline.resolvers.serviceAccountName" -}}
+{{- if .Values.serviceaccount.enabled -}}
+tekton-pipelines-resolvers
+{{- else -}}
+{{- default "tekton-pipelines-resolvers" .Values.serviceaccount.names.resolvers -}}
+{{- end -}}
+{{- end -}}

--- a/charts/tekton-pipeline/templates/tekton-events-controller-cluster-access-crb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-cluster-access-crb.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-events-controller
+    name: {{ include "tektonPipeline.eventsController.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: ClusterRole

--- a/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
@@ -101,7 +101,7 @@ spec:
         - mountPath: /etc/config-registry-cert
           name: config-registry-cert
         image: {{ .Values.eventscontroller.deployment.image }}
-      serviceAccountName: tekton-events-controller
+      serviceAccountName: {{ include "tektonPipeline.eventsController.serviceAccountName" . }}
       volumes:
       - configMap:
           name: config-logging

--- a/charts/tekton-pipeline/templates/tekton-events-controller-leaderelection-rb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-leaderelection-rb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-events-controller
+    name: {{ include "tektonPipeline.eventsController.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: Role

--- a/charts/tekton-pipeline/templates/tekton-events-controller-sa.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-sa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceaccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,3 +7,7 @@ metadata:
     app.kubernetes.io/component: events
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
+  {{- with .Values.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-cluster-access-crb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-cluster-access-crb.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-pipelines-controller
+    name: {{ include "tektonPipeline.controller.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: ClusterRole

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -146,7 +146,7 @@ spec:
           {{- with .Values.controller.nodeSelector }}
             {{- toYaml . |  nindent 8 }}
           {{- end}}
-      serviceAccountName: tekton-pipelines-controller
+      serviceAccountName: {{ include "tektonPipeline.controller.serviceAccountName" . }}
       tolerations:
           {{- with .Values.controller.tolerations }}
             {{- toYaml . |  nindent 6 }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-leaderelection-rb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-leaderelection-rb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-pipelines-controller
+    name: {{ include "tektonPipeline.controller.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: Role

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-rb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-rb.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-pipelines-controller
+    name: {{ include "tektonPipeline.controller.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: Role

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-sa.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-sa.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- if .Values.serviceaccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -19,3 +20,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
+  {{- with .Values.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-tenant-access-crb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-tenant-access-crb.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-pipelines-controller
+    name: {{ include "tektonPipeline.controller.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: ClusterRole

--- a/charts/tekton-pipeline/templates/tekton-pipelines-events-controller-rb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-events-controller-rb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-events-controller
+    name: {{ include "tektonPipeline.eventsController.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: Role

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -112,7 +112,7 @@ spec:
           {{- with .Values.remoteresolver.nodeSelector }}
             {{- toYaml . |  nindent 8 }}
           {{- end}}
-      serviceAccountName: tekton-pipelines-resolvers
+      serviceAccountName: {{ include "tektonPipeline.resolvers.serviceAccountName" . }}
       tolerations:
           {{- with .Values.remoteresolver.tolerations }}
             {{- toYaml . |  nindent 6 }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-resolvers-crb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-resolvers-crb.yaml
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-pipelines-resolvers
+    name: {{ include "tektonPipeline.resolvers.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: ClusterRole

--- a/charts/tekton-pipeline/templates/tekton-pipelines-resolvers-namespace-rbac-rb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-resolvers-namespace-rbac-rb.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-pipelines-resolvers
+    name: {{ include "tektonPipeline.resolvers.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: Role

--- a/charts/tekton-pipeline/templates/tekton-pipelines-resolvers-sa.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-resolvers-sa.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{ if .Values.serviceaccount.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -20,3 +21,7 @@ metadata:
     app.kubernetes.io/component: resolvers
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
+  {{- with .Values.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-cluster-access-crb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-cluster-access-crb.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-pipelines-webhook
+    name: {{ include "tektonPipeline.webhook.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: ClusterRole

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -131,7 +131,7 @@ spec:
           {{- with .Values.webhook.nodeSelector }}
             {{- toYaml . |  nindent 8 }}
           {{- end}}
-      serviceAccountName: tekton-pipelines-webhook
+      serviceAccountName: {{ include "tektonPipeline.webhook.serviceAccountName" . }}
       tolerations:
           {{- with .Values.webhook.tolerations }}
             {{- toYaml . |  nindent 6 }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-leaderelection-rb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-leaderelection-rb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-pipelines-webhook
+    name: {{ include "tektonPipeline.webhook.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: Role

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-rb.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-rb.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
-    name: tekton-pipelines-webhook
+    name: {{ include "tektonPipeline.webhook.serviceAccountName" . }}
     namespace: '{{ .Release.Namespace }}'
 roleRef:
   kind: Role

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-sa.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-sa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceaccount.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,3 +7,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
+  {{- with .Values.serviceaccount.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -20,8 +20,19 @@ auth:
     # https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#configuring-docker-authentication-for-docker
     configJson: ""
 serviceaccount:
+  # true:  the chart creates the ServiceAccounts and all workloads/RBAC use the
+  #        chart-generated names.
+  # false: the chart does NOT create the ServiceAccounts; workloads/RBAC use the
+  #        names provided under `names` below (bring your own ServiceAccount).
   enabled: true
   annotations: {}
+  # Only used when `enabled` is false. Provide the name of your existing
+  # ServiceAccount per component. If left empty, the chart-generated name is used.
+  names:
+    controller: ""
+    webhook: ""
+    eventsController: ""
+    resolvers: ""
 # Values for tekton-pipelines-controller
 controller:
   deployment:


### PR DESCRIPTION
## Summary

Adds the ability to bring your own ServiceAccounts instead of having the chart create them.

The existing `serviceaccount.enabled` value now controls this behaviour:
- `enabled: true` (default): the chart creates the controller, webhook, events-controller and remote-resolvers ServiceAccounts and all workloads/RBAC use the chart-generated names (unchanged behaviour).
- `enabled: false`: the chart does **not** create those ServiceAccounts; the deployments and all RBAC bindings instead use the names provided under `serviceaccount.names.<component>`. Empty overrides fall back to the chart-generated names.

```yaml
serviceaccount:
  enabled: false
  names:
    controller: my-existing-controller-sa
    webhook: my-existing-webhook-sa
    eventsController: my-events-sa
    resolvers: my-resolvers-sa
```

ClusterRoles/Roles and their bindings are always created and bound to the resolved SA name, so a bring-your-own SA still receives the required RBAC. The unrelated `tekton-bot` workload SA is untouched.

## Changes
- New `templates/_helpers.tpl` with per-component ServiceAccount name resolvers.
- `values.yaml`: extended `serviceaccount` block with `names.{controller,webhook,eventsController,resolvers}`.
- 4 ServiceAccount templates guarded by `serviceaccount.enabled`.
- 4 deployments and 12 RBAC binding subjects wired to the resolved names.

## Testing
- `helm template` with default values is byte-identical to the previous output.
- `helm template` with `enabled: false` + custom names: no SAs created; all deployments and bindings reference the provided names; empty-override fallback verified.
- `helm lint` passes.