### PR TITLE
feat: add per-component imagePullSecrets

### DIFF
--- a/charts/tekton-pipeline/patches/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-events-controller-deploy.yaml
@@ -5,6 +5,11 @@ metadata:
 spec:
   template:
     spec:
+      imagePullSecrets:
+        helmTemplateRemoveMe: |
+          {{- with .Values.eventscontroller.imagePullSecrets }}
+            {{- toYaml . | nindent 6 }}
+          {{- end }}
       containers:
       - name: tekton-events-controller
       helmTemplateRemoveMe: |

--- a/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-controller-deploy.yaml
@@ -22,6 +22,11 @@ spec:
             {{- toYaml . | nindent 8 }}
           {{- end}}
     spec:
+      imagePullSecrets:
+        helmTemplateRemoveMe: |
+          {{- with .Values.controller.imagePullSecrets }}
+            {{- toYaml . | nindent 6 }}
+          {{- end }}
       affinity:
         helmTemplateRemoveMe: |
           {{- with .Values.controller.affinity }}

--- a/charts/tekton-pipeline/patches/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -5,6 +5,11 @@ metadata:
 spec:
   template:
     spec:
+      imagePullSecrets:
+        helmTemplateRemoveMe: |
+          {{- with .Values.remoteresolver.imagePullSecrets }}
+            {{- toYaml . | nindent 6 }}
+          {{- end }}
       affinity:
         helmTemplateRemoveMe: |
           {{- with .Values.remoteresolver.affinity }}

--- a/charts/tekton-pipeline/patches/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/patches/tekton-pipelines-webhook-deploy.yaml
@@ -16,6 +16,11 @@ spec:
             {{- toYaml . | nindent 8 }}
           {{- end}}
     spec:
+      imagePullSecrets:
+        helmTemplateRemoveMe: |
+          {{- with .Values.webhook.imagePullSecrets }}
+            {{- toYaml . | nindent 6 }}
+          {{- end }}
       affinity:
         helmTemplateRemoveMe: |
           {{- with .Values.webhook.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
@@ -101,6 +101,10 @@ spec:
         - mountPath: /etc/config-registry-cert
           name: config-registry-cert
         image: {{ .Values.eventscontroller.deployment.image }}
+      imagePullSecrets:
+          {{- with .Values.eventscontroller.imagePullSecrets }}
+            {{- toYaml . | nindent 6 }}
+          {{- end }}
       serviceAccountName: tekton-events-controller
       volumes:
       - configMap:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -142,6 +142,10 @@ spec:
         - mountPath: /etc/config-registry-cert
           name: config-registry-cert
         image: {{ .Values.controller.deployment.image }}
+      imagePullSecrets:
+          {{- with .Values.controller.imagePullSecrets }}
+            {{- toYaml . | nindent 6 }}
+          {{- end }}
       nodeSelector:
           {{- with .Values.controller.nodeSelector }}
             {{- toYaml . |  nindent 8 }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -108,6 +108,10 @@ spec:
         - mountPath: /tmp
           name: tmp-clone-volume
         image: {{ .Values.remoteresolver.deployment.image }}
+      imagePullSecrets:
+          {{- with .Values.remoteresolver.imagePullSecrets }}
+            {{- toYaml . | nindent 6 }}
+          {{- end }}
       nodeSelector:
           {{- with .Values.remoteresolver.nodeSelector }}
             {{- toYaml . |  nindent 8 }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -127,6 +127,10 @@ spec:
           seccompProfile:
             type: RuntimeDefault
         image: {{ .Values.webhook.deployment.image }}
+      imagePullSecrets:
+          {{- with .Values.webhook.imagePullSecrets }}
+            {{- toYaml . | nindent 6 }}
+          {{- end }}
       nodeSelector:
           {{- with .Values.webhook.nodeSelector }}
             {{- toYaml . |  nindent 8 }}

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -52,6 +52,9 @@ controller:
   tolerations: []
   nodeSelector: {}
   resources: {}
+  # Secrets used to pull the controller image from a private registry.
+  imagePullSecrets: []
+  # - name: my-registry-secret
 # Values for tekton-pipelines-webhook
 webhook:
   deployment:
@@ -73,6 +76,9 @@ webhook:
                   - windows
   tolerations: []
   nodeSelector: {}
+  # Secrets used to pull the webhook image from a private registry.
+  imagePullSecrets: []
+  # - name: my-registry-secret
 # Values to amend tekton-pipelines-remote-resolvers
 remoteresolver:
   deployment:
@@ -87,10 +93,16 @@ remoteresolver:
     limits:
       cpu: 1000m
       memory: 4Gi
+  # Secrets used to pull the resolvers image from a private registry.
+  imagePullSecrets: []
+  # - name: my-registry-secret
 # Values for tekton-events-controller
 eventscontroller:
   deployment:
     image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.12.2@sha256:facd8325f8cf78f63d5e687faaed5cc2c0d4111da72464083ceff00a7e0b3c56
+  # Secrets used to pull the events controller image from a private registry.
+  imagePullSecrets: []
+  # - name: my-registry-secret
 # configuration to put in the config-defaults ConfigMap
 configDefaults:
   _example: |


### PR DESCRIPTION
## Summary

Adds support for configuring `imagePullSecrets` on all chart deployments (controller, webhook, remote-resolvers, events-controller).

```yaml
controller:
  imagePullSecrets:
    - name: my-registry-secret
webhook:
  imagePullSecrets:
    - name: my-registry-secret
remoteresolver:
  imagePullSecrets:
    - name: my-registry-secret
eventscontroller:
  imagePullSecrets:
    - name: my-registry-secret
```

## Note on `global.imagePullSecrets`

I initially explored a top-level `global.imagePullSecrets` that would apply to all deployments at once, but **skipped it because of the chart's generation mechanism**. This chart is generated: `make fetch` downloads the upstream manifests and re-applies the chart's customizations via the kustomize patch layer (and Makefile transforms), wiping any direct edits to `templates/`. A `global` option that merges/deduplicates across components would have required shared template logic (a `_helpers.tpl`) and additional moving parts that don't fit cleanly into that generation flow.

**Per-component `imagePullSecrets` are now implemented**, which covers the use case while staying consistent with how the chart's source is structured.

## Implementation

Changes are made to the chart **source** (not the generated output), so they survive `make fetch`:
- `values.yaml`: `imagePullSecrets: []` added to each of the four component blocks.
- `patches/*-deploy.yaml`: each deployment patch injects `imagePullSecrets` into the pod spec via the existing `helmTemplateRemoveMe` convention used for affinity/tolerations/etc.

No changes to `kustomization.yaml` are needed since all four deployments are already patched.

## Testing

- Verified the kustomize patch + `sed '/helmTemplateRemoveMe/d'` pipeline produces the expected Helm template output (`imagePullSecrets:` at pod-spec indentation with the `{{- with }}` block).
- `helm template` renders nothing extra when the list is empty (default) and renders the configured secrets when set (single and multiple entries verified).
- `helm lint` passes.