### PR TITLE
chore(bump): upgrade Tekton pipeline manifests to v1.14.0

### DIFF
--- a/charts/tekton-pipeline/Chart.yaml
+++ b/charts/tekton-pipeline/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for Tekton Pipelines
 name: tekton-pipeline
-version: 1.12.2
-appVersion: 1.12.2
+version: 1.14.0
+appVersion: 1.14.0
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/cdfoundation/tekton-helm-chart

--- a/charts/tekton-pipeline/crds/customruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/customruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
-    version: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
+    version: "v1.14.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/pipelineruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/pipelineruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
-    version: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
+    version: "v1.14.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -2379,6 +2379,8 @@ spec:
                             once we're confident old PipelineRuns have been cleaned up.
                             See issue #8359 for context.
                           type: boolean
+                        enableTerminationMessageCompression:
+                          type: boolean
                         enableWaitExponentialBackoff:
                           type: boolean
                         enforceNonfalsifiability:
@@ -2757,6 +2759,8 @@ spec:
                                       once we're confident old PipelineRuns have been cleaned up.
                                       See issue #8359 for context.
                                     type: boolean
+                                  enableTerminationMessageCompression:
+                                    type: boolean
                                   enableWaitExponentialBackoff:
                                     type: boolean
                                   enforceNonfalsifiability:
@@ -3027,6 +3031,8 @@ spec:
                                             This field is not used and can be removed in a future release
                                             once we're confident old PipelineRuns have been cleaned up.
                                             See issue #8359 for context.
+                                          type: boolean
+                                        enableTerminationMessageCompression:
                                           type: boolean
                                         enableWaitExponentialBackoff:
                                           type: boolean
@@ -5471,6 +5477,8 @@ spec:
                             This field is not used and can be removed in a future release
                             once we're confident old PipelineRuns have been cleaned up.
                             See issue #8359 for context.
+                          type: boolean
+                        enableTerminationMessageCompression:
                           type: boolean
                         enableWaitExponentialBackoff:
                           type: boolean

--- a/charts/tekton-pipeline/crds/pipelines.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/pipelines.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
-    version: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
+    version: "v1.14.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -835,8 +835,10 @@ spec:
                         x-kubernetes-list-type: atomic
                       pipelineRef:
                         description: |-
-                          PipelineRef is a reference to a pipeline definition
-                          Note: PipelineRef is in preview mode and not yet supported
+                          PipelineRef is a reference to a pipeline definition.
+                          This is an alpha field. You must set the "enable-api-fields" feature flag
+                          to "alpha" for this field to be supported. When enabled, the referenced
+                          Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
                         type: object
                         properties:
                           apiVersion:
@@ -871,8 +873,10 @@ spec:
                             type: string
                       pipelineSpec:
                         description: |-
-                          PipelineSpec is a specification of a pipeline
-                          Note: PipelineSpec is in preview mode and not yet supported
+                          PipelineSpec is a specification of a pipeline.
+                          This is an alpha field. You must set the "enable-api-fields" feature flag
+                          to "alpha" for this field to be supported. When enabled, the embedded
+                          Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
                           Specifying PipelineSpec can be disabled by setting
                           `disable-inline-spec` feature flag.
                           See Pipeline.spec (API version: tekton.dev/v1)
@@ -1174,8 +1178,10 @@ spec:
                         x-kubernetes-list-type: atomic
                       pipelineRef:
                         description: |-
-                          PipelineRef is a reference to a pipeline definition
-                          Note: PipelineRef is in preview mode and not yet supported
+                          PipelineRef is a reference to a pipeline definition.
+                          This is an alpha field. You must set the "enable-api-fields" feature flag
+                          to "alpha" for this field to be supported. When enabled, the referenced
+                          Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
                         type: object
                         properties:
                           apiVersion:
@@ -1210,8 +1216,10 @@ spec:
                             type: string
                       pipelineSpec:
                         description: |-
-                          PipelineSpec is a specification of a pipeline
-                          Note: PipelineSpec is in preview mode and not yet supported
+                          PipelineSpec is a specification of a pipeline.
+                          This is an alpha field. You must set the "enable-api-fields" feature flag
+                          to "alpha" for this field to be supported. When enabled, the embedded
+                          Pipeline is executed as a child PipelineRun owned by the parent PipelineRun.
                           Specifying PipelineSpec can be disabled by setting
                           `disable-inline-spec` feature flag.
                           See Pipeline.spec (API version: tekton.dev/v1)

--- a/charts/tekton-pipeline/crds/stepactions.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/stepactions.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
-    version: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
+    version: "v1.14.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false

--- a/charts/tekton-pipeline/crds/taskruns.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/taskruns.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
-    version: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
+    version: "v1.14.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -1894,6 +1894,8 @@ spec:
                             once we're confident old PipelineRuns have been cleaned up.
                             See issue #8359 for context.
                           type: boolean
+                        enableTerminationMessageCompression:
+                          type: boolean
                         enableWaitExponentialBackoff:
                           type: boolean
                         enforceNonfalsifiability:
@@ -2164,6 +2166,8 @@ spec:
                                   This field is not used and can be removed in a future release
                                   once we're confident old PipelineRuns have been cleaned up.
                                   See issue #8359 for context.
+                                type: boolean
+                              enableTerminationMessageCompression:
                                 type: boolean
                               enableWaitExponentialBackoff:
                                 type: boolean
@@ -4044,6 +4048,8 @@ spec:
                             once we're confident old PipelineRuns have been cleaned up.
                             See issue #8359 for context.
                           type: boolean
+                        enableTerminationMessageCompression:
+                          type: boolean
                         enableWaitExponentialBackoff:
                           type: boolean
                         enforceNonfalsifiability:
@@ -4306,6 +4312,8 @@ spec:
                                   This field is not used and can be removed in a future release
                                   once we're confident old PipelineRuns have been cleaned up.
                                   See issue #8359 for context.
+                                type: boolean
+                              enableTerminationMessageCompression:
                                 type: boolean
                               enableWaitExponentialBackoff:
                                 type: boolean

--- a/charts/tekton-pipeline/crds/tasks.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/tasks.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
-    version: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
+    version: "v1.14.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -1510,8 +1510,6 @@ spec:
                 stepTemplate:
                   description: StepTemplate
                   type: object
-                  required:
-                    - name
                   properties:
                     args:
                       description: Args

--- a/charts/tekton-pipeline/crds/verificationpolicies.tekton.dev-crd.yaml
+++ b/charts/tekton-pipeline/crds/verificationpolicies.tekton.dev-crd.yaml
@@ -19,8 +19,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
-    version: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
+    version: "v1.14.0"
 spec:
   group: tekton.dev
   versions:

--- a/charts/tekton-pipeline/templates/config-tracing-cm.yaml
+++ b/charts/tekton-pipeline/templates/config-tracing-cm.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# NOTE: Exported traces may include Kubernetes resource identifiers (e.g. TaskRun/PipelineRun
+# names and namespaces) as span attributes. Treat the trace backend as a trusted observability
+# system. See docs/developers/tracing.md for details.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/config.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
+++ b/charts/tekton-pipeline/templates/pipelines-info-cm.yaml
@@ -25,4 +25,4 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace we still can have access to
   # this ConfigMap.
-  version: "v1.12.2"
+  version: "v1.14.0"

--- a/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-deploy.yaml
@@ -6,9 +6,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: events
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.12.2
-    pipeline.tekton.dev/release: v1.12.2
-    version: v1.12.2
+    app.kubernetes.io/version: v1.14.0
+    pipeline.tekton.dev/release: v1.14.0
+    version: v1.14.0
   name: tekton-events-controller
 spec:
   replicas: 1
@@ -26,9 +26,9 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: events
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.12.2
-        pipeline.tekton.dev/release: v1.12.2
-        version: v1.12.2
+        app.kubernetes.io/version: v1.14.0
+        pipeline.tekton.dev/release: v1.14.0
+        version: v1.14.0
     spec:
       affinity:
         nodeAffinity:

--- a/charts/tekton-pipeline/templates/tekton-events-controller-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-events-controller-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: events
     app.kubernetes.io/component: events
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.2"
+    app.kubernetes.io/version: "v1.14.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-events-controller
-    version: "v1.12.2"
+    version: "v1.14.0"
   name: tekton-events-controller
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: controller
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.12.2
+    app.kubernetes.io/version: v1.14.0
       {{- with .Values.controller.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v1.12.2
-    version: v1.12.2
+    pipeline.tekton.dev/release: v1.14.0
+    version: v1.14.0
   name: tekton-pipelines-controller
 spec:
   replicas: 1
@@ -34,12 +34,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: controller
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.12.2
+        app.kubernetes.io/version: v1.14.0
           {{- with .Values.controller.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v1.12.2
-        version: v1.12.2
+        pipeline.tekton.dev/release: v1.14.0
+        version: v1.14.0
     spec:
       affinity:
           {{- with .Values.controller.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-controller-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.2"
+    app.kubernetes.io/version: "v1.14.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-controller
-    version: "v1.12.2"
+    version: "v1.14.0"
   name: tekton-pipelines-controller
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-deploy.yaml
@@ -6,9 +6,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.12.2
-    pipeline.tekton.dev/release: v1.12.2
-    version: v1.12.2
+    app.kubernetes.io/version: v1.14.0
+    pipeline.tekton.dev/release: v1.14.0
+    version: v1.14.0
   name: tekton-pipelines-remote-resolvers
 spec:
   replicas: 1
@@ -26,9 +26,9 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: resolvers
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.12.2
-        pipeline.tekton.dev/release: v1.12.2
-        version: v1.12.2
+        app.kubernetes.io/version: v1.14.0
+        pipeline.tekton.dev/release: v1.14.0
+        version: v1.14.0
     spec:
       affinity:
           {{- with .Values.remoteresolver.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-remote-resolvers-svc.yaml
@@ -18,13 +18,13 @@ metadata:
     app.kubernetes.io/name: resolvers
     app.kubernetes.io/component: resolvers
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.2"
+    app.kubernetes.io/version: "v1.14.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-remote-resolvers
-    version: "v1.12.2"
+    version: "v1.14.0"
   name: tekton-pipelines-remote-resolvers
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-deploy.yaml
@@ -6,12 +6,12 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: webhook
     app.kubernetes.io/part-of: tekton-pipelines
-    app.kubernetes.io/version: v1.12.2
+    app.kubernetes.io/version: v1.14.0
       {{- with .Values.webhook.deployment.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end}}
-    pipeline.tekton.dev/release: v1.12.2
-    version: v1.12.2
+    pipeline.tekton.dev/release: v1.14.0
+    version: v1.14.0
   name: tekton-pipelines-webhook
 spec:
   selector:
@@ -28,12 +28,12 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: webhook
         app.kubernetes.io/part-of: tekton-pipelines
-        app.kubernetes.io/version: v1.12.2
+        app.kubernetes.io/version: v1.14.0
           {{- with .Values.webhook.pod.labels }}
             {{- toYaml . | nindent 8 }}
           {{- end}}
-        pipeline.tekton.dev/release: v1.12.2
-        version: v1.12.2
+        pipeline.tekton.dev/release: v1.14.0
+        version: v1.14.0
     spec:
       affinity:
           {{- with .Values.webhook.affinity }}

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-horizontalpodautoscaler.yaml
@@ -20,12 +20,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.2"
+    app.kubernetes.io/version: "v1.14.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v1.12.2"
+    version: "v1.14.0"
 spec:
   minReplicas: 1
   maxReplicas: 5

--- a/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
+++ b/charts/tekton-pipeline/templates/tekton-pipelines-webhook-svc.yaml
@@ -5,13 +5,13 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v1.12.2"
+    app.kubernetes.io/version: "v1.14.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-webhook
-    version: "v1.12.2"
+    version: "v1.14.0"
   name: tekton-pipelines-webhook
 spec:
   ports:

--- a/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/validation.webhook.pipeline.tekton.dev-valwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
+++ b/charts/tekton-pipeline/templates/webhook-certs-secret.yaml
@@ -20,5 +20,5 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
     # The data is populated at install time.

--- a/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
+++ b/charts/tekton-pipeline/templates/webhook.pipeline.tekton.dev-mutwebhookcfg.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v1.12.2"
+    pipeline.tekton.dev/release: "v1.14.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:

--- a/charts/tekton-pipeline/values.yaml
+++ b/charts/tekton-pipeline/values.yaml
@@ -25,13 +25,13 @@ serviceaccount:
 # Values for tekton-pipelines-controller
 controller:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.12.2@sha256:76728a24a606d6f2205ae50e31bb08a1b185b60a2456fe7d9c73c175047ce5aa
+    image: ghcr.io/tektoncd/pipeline/controller-10a3e32792f33651396d02b6855a6e36:v1.14.0@sha256:5209c1969c407d36d9c2c5217a8b0700a9fb52b3068b6fbdce0d88ead397ea75
     labels: {}
   images:
-    entrypoint: "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.12.2@sha256:7def477fc1d36ab1d38f2872dfeaf62cc43c0ebacf117eed62caa39fea0c7db2"
-    nop: "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.12.2@sha256:23a7308656c90b9ef73b01ddc03ab19a80282a66a9cd505f97540e75213e4f9b"
-    sidecarlogresults: "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.12.2@sha256:20f72f06804a52ba851f41fc06644d750871769c3e94e0b99e940a0f837a1368"
-    workingdirinit: "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.12.2@sha256:fd8aeb5a1a73757ee36713880bd712b3d8a6c5f94f963e34193a7fbd32c77c65"
+    entrypoint: "ghcr.io/tektoncd/pipeline/entrypoint-bff0a22da108bc2f16c818c97641a296:v1.14.0@sha256:e3e7a41a23f8d8cafac7b964187d414d5fcbe503b34d50e2b579ce2a36cfa522"
+    nop: "ghcr.io/tektoncd/pipeline/nop-8eac7c133edad5df719dc37b36b62482:v1.14.0@sha256:4768edf4d3ccaa7b0e590a7840176a1d12af4cd9ed4fcdccf46a7aa57b80649f"
+    sidecarlogresults: "ghcr.io/tektoncd/pipeline/sidecarlogresults-7501c6a20d741631510a448b48ab098f:v1.14.0@sha256:db616ab753d84dd2e27dac8c4bafe50b81b638d92933390cfaa2cff0169c26f4"
+    workingdirinit: "ghcr.io/tektoncd/pipeline/workingdirinit-0c558922ec6a1b739e550e349f2d5fc1:v1.14.0@sha256:7f9394bf30aa055e03a81b1c2882152b9df947353ffd17c681e205488fd7762d"
     shellImage: "cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791"
     shellImageWin: "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6"
   pod:
@@ -58,7 +58,7 @@ controller:
 # Values for tekton-pipelines-webhook
 webhook:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.12.2@sha256:12d542c81d166c26546b0cad60fa1e2a7d5c4b5dc9ad30612d3feb939ce1d12c
+    image: ghcr.io/tektoncd/pipeline/webhook-d4749e605405422fd87700164e31b2d1:v1.14.0@sha256:dab27b10a60e56cbeb444d84356835b145c3d8491a7afe77353b1b999eb3a867
     labels: {}
   pod:
     labels: {}
@@ -82,7 +82,7 @@ webhook:
 # Values to amend tekton-pipelines-remote-resolvers
 remoteresolver:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.12.2@sha256:6047be2af74b86129eb22b76ca908754c932208573e0a62a5f498da99b552e6a
+    image: ghcr.io/tektoncd/pipeline/resolvers-ff86b24f130c42b88983d3c13993056d:v1.14.0@sha256:7516b1750c7147fbe2e48e8d334acff74a02aad68696c9cf2f32a2790bc4dbf9
   affinity: {}
   tolerations: []
   nodeSelector: {}
@@ -99,7 +99,7 @@ remoteresolver:
 # Values for tekton-events-controller
 eventscontroller:
   deployment:
-    image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.12.2@sha256:facd8325f8cf78f63d5e687faaed5cc2c0d4111da72464083ceff00a7e0b3c56
+    image: ghcr.io/tektoncd/pipeline/events-a9042f7efb0cbade2a868a1ee5ddd52c:v1.14.0@sha256:7ccdab7772fc5aa74987b53a5246e5c6863a653d13484bf535a3a15d96e3cd21
   # Secrets used to pull the events controller image from a private registry.
   imagePullSecrets: []
   # - name: my-registry-secret
@@ -181,10 +181,12 @@ configDefaults:
     # Possible values include "1m", "5m", "10s", "1h", etc.
     # Example: default-maximum-resolution-timeout: "1m"
 
-    # default-container-resource-requirements allow users to update default resource requirements
-    # to a init-containers and containers of a pods create by the controller
-    # Onet: All the resource requirements are applied to init-containers and containers
-    # only if the existing resource requirements are empty.
+    # default-container-resource-requirements allow users to configure default resource
+    # requirements for init containers and containers in pods created by the controller.
+    # No resource requirements are applied by default when this key is unset.
+    # Note: All the resource requirements are applied to init-containers and containers
+    # only if the existing resource requirements are empty, except Tekton internal
+    # containers can be overridden by named entries such as prepare or place-scripts.
     # default-container-resource-requirements: |
     #   place-scripts: # updates resource requirements of a 'place-scripts' container
     #     requests:
@@ -393,3 +395,10 @@ featureFlags:
   # If set to "false", exponential backoff will be disabled.
   # For advanced tuning of backoff parameters, update the 'wait-exponential-backoff' ConfigMap.
   enable-wait-exponential-backoff: "false"
+  # Setting this flag to "true" will compress termination messages with flate
+  # to fit more results in the 4KB Kubernetes termination message limit.
+  # Only applies when results-from is set to "termination-message" (the default);
+  # ignored when results-from is "sidecar-logs".
+  # Alpha feature — this is a short-term measure. External result storage
+  # (TEP-0164) will address the underlying 4KB limitation.
+  enable-termination-message-compression: "false"


### PR DESCRIPTION
## Summary

Upgrades Tekton Pipeline manifests from v1.12.2 to v1.14.0.

## Related

- [v1.13.0](https://github.com/tektoncd/pipeline/releases/tag/v1.13.0)
- [v1.13.1](https://github.com/tektoncd/pipeline/releases/tag/v1.13.1)
- [v1.14.0](https://github.com/tektoncd/pipeline/releases/tag/v1.14.0)